### PR TITLE
fix: remove dead PAUSED enum + add reconciliation/WS handler tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -369,3 +369,9 @@
 
 - Add shared `spine` fixture in [`tests/conftest.py`](tests/conftest.py) for test harness consolidation
 - Remove duplicate `spine` fixture definitions from 6 test files
+
+## v0.36.0 on 16th of March, 2026
+
+- Remove dead `TradeStatus.PAUSED` enum member and docstring reference from [`enums.py`](praxis/core/domain/enums.py)
+- Add 26 tests for startup reconciliation (`_reconcile_account`, `_reconcile_fills`, `_reconcile_terminal`) and WebSocket handler (`_on_execution_report`, `_convert_execution_report`) in [`test_trading.py`](tests/test_trading.py)
+- Update `test_domain_outcome.py` to reflect PAUSED removal from `_NON_TERMINAL` list and `test_trade_status_members` expected set

--- a/praxis/core/domain/enums.py
+++ b/praxis/core/domain/enums.py
@@ -116,13 +116,12 @@ class TradeStatus(Enum):
     '''
     Define trade-level execution status per Consensus #22.
 
-    Non-terminal: PENDING, PARTIAL, PAUSED.
+    Non-terminal: PENDING, PARTIAL.
     Terminal: FILLED, CANCELED, REJECTED, EXPIRED.
     '''
 
     PENDING = 'PENDING'
     PARTIAL = 'PARTIAL'
-    PAUSED = 'PAUSED'
     FILLED = 'FILLED'
     CANCELED = 'CANCELED'
     REJECTED = 'REJECTED'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum-praxis"
-version = "0.35.0"
+version = "0.36.0"
 description = "Execution system for Vaquum — Trading sub-system + Account sub-system."
 readme = "README.md"
 authors = [

--- a/tests/test_domain_outcome.py
+++ b/tests/test_domain_outcome.py
@@ -15,7 +15,7 @@ from praxis.core.domain import TradeOutcome, TradeStatus
 _TS = datetime(2026, 1, 1, tzinfo=timezone.utc)
 
 _TERMINAL = [TradeStatus.CANCELED, TradeStatus.EXPIRED, TradeStatus.FILLED, TradeStatus.REJECTED]
-_NON_TERMINAL = [TradeStatus.PARTIAL, TradeStatus.PAUSED, TradeStatus.PENDING]
+_NON_TERMINAL = [TradeStatus.PARTIAL, TradeStatus.PENDING]
 _SLICES = 5
 
 
@@ -50,7 +50,6 @@ def test_trade_status_members() -> None:
     expected = {
         TradeStatus.PENDING,
         TradeStatus.PARTIAL,
-        TradeStatus.PAUSED,
         TradeStatus.FILLED,
         TradeStatus.CANCELED,
         TradeStatus.REJECTED,

--- a/tests/test_trading.py
+++ b/tests/test_trading.py
@@ -10,6 +10,7 @@ import pytest
 
 from praxis.core.domain.enums import (
     ExecutionMode,
+    ExecutionType,
     MakerPreference,
     OrderSide,
     OrderStatus,
@@ -18,11 +19,15 @@ from praxis.core.domain.enums import (
     TradeStatus,
 )
 from praxis.core.domain.position import Position
+from praxis.core.domain.order import Order
 from praxis.core.domain.single_shot_params import SingleShotParams
 from praxis.core.domain.trade_abort import TradeAbort
 from praxis.core.domain.events import (
     CommandAccepted,
     FillReceived,
+    OrderCanceled,
+    OrderExpired,
+    OrderRejected,
     OrderSubmitIntent,
     OrderSubmitted,
     TradeOutcomeProduced,
@@ -40,6 +45,7 @@ from praxis.infrastructure.venue_adapter import (
     SubmitResult,
     SymbolFilters,
     VenueAdapter,
+    VenueError,
     VenueOrder,
     VenueTrade,
 )
@@ -771,3 +777,824 @@ async def test_trading_shutdown_cancels_oco_orders_via_cancel_order_list(
 
     assert ('acc-1', 'oco-list-1') in adapter.cancel_list_calls
     assert ('acc-1', 'oco-list-1') not in adapter.cancel_calls
+
+
+class _ReconVenueAdapter(_InjectedVenueAdapter):
+
+    def __init__(self) -> None:
+        self._venue_orders: dict[str, VenueOrder] = {}
+        self._venue_trades: list[VenueTrade] = []
+
+    async def query_order(
+        self,
+        account_id: str,
+        symbol: str,
+        *,
+        venue_order_id: str | None = None,
+        client_order_id: str | None = None,
+    ) -> VenueOrder:
+        del account_id, symbol, venue_order_id
+        key = client_order_id or ''
+        if key in self._venue_orders:
+            return self._venue_orders[key]
+        raise NotFoundError('not found')
+
+    async def query_trades(
+        self,
+        account_id: str,
+        symbol: str,
+        *,
+        start_time: datetime | None = None,
+    ) -> list[VenueTrade]:
+        del account_id, symbol, start_time
+        return self._venue_trades
+
+    async def cancel_order(
+        self,
+        account_id: str,
+        symbol: str,
+        *,
+        venue_order_id: str | None = None,
+        client_order_id: str | None = None,
+    ) -> CancelResult:
+        del account_id, symbol, venue_order_id, client_order_id
+        return CancelResult(venue_order_id='v-1', status=OrderStatus.CANCELED)
+
+
+def _make_order(
+    client_order_id: str = 'SS-cmd1-00',
+    venue_order_id: str = 'v-1',
+    command_id: str = 'cmd-1',
+    status: OrderStatus = OrderStatus.OPEN,
+    filled_qty: Decimal = Decimal('0'),
+) -> Order:
+    return Order(
+        client_order_id=client_order_id,
+        venue_order_id=venue_order_id,
+        account_id='acc-1',
+        command_id=command_id,
+        symbol='BTCUSDT',
+        side=OrderSide.BUY,
+        order_type=OrderType.MARKET,
+        qty=Decimal('1'),
+        filled_qty=filled_qty,
+        price=None,
+        stop_price=None,
+        status=status,
+        created_at=_CREATED_AT,
+        updated_at=_CREATED_AT,
+    )
+
+
+async def _started_trading_with_recon_adapter(
+    spine: EventSpine,
+) -> tuple[Trading, _ReconVenueAdapter]:
+    adapter = _ReconVenueAdapter()
+    trading = Trading(
+        config=TradingConfig(
+            epoch_id=1,
+            account_credentials={'acc-1': ('key', 'secret')},
+            shutdown_timeout=0.1,
+        ),
+        event_spine=spine,
+        venue_adapter=cast(VenueAdapter, adapter),
+    )
+    await trading.start()
+    return trading, adapter
+
+
+@pytest.mark.asyncio
+async def test_reconcile_account_skips_terminal_orders(spine: EventSpine) -> None:
+    trading, _ = await _started_trading_with_recon_adapter(spine)
+    order = _make_order(status=OrderStatus.FILLED, filled_qty=Decimal('1'))
+    trading._execution_manager._accounts['acc-1'].trading_state.orders['SS-cmd1-00'] = order
+
+    await trading._reconcile_account('acc-1')
+
+    events = await spine.read(1)
+    assert len(events) == 0
+    await trading.stop()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_account_handles_not_found(spine: EventSpine) -> None:
+    trading, _ = await _started_trading_with_recon_adapter(spine)
+    order = _make_order()
+    trading._execution_manager._accounts['acc-1'].trading_state.orders['SS-cmd1-00'] = order
+
+    await trading._reconcile_account('acc-1')
+
+    events = await spine.read(1)
+    assert len(events) == 0
+    await trading.stop()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_account_reconciles_fills_when_venue_has_more(
+    spine: EventSpine,
+) -> None:
+    trading, adapter = await _started_trading_with_recon_adapter(spine)
+    order = _make_order()
+    trading._execution_manager._accounts['acc-1'].trading_state.orders['SS-cmd1-00'] = order
+    trading._execution_manager._command_trade_ids['cmd-1'] = 'trade-1'
+
+    adapter._venue_orders['SS-cmd1-00'] = VenueOrder(
+        venue_order_id='v-1',
+        client_order_id='SS-cmd1-00',
+        status=OrderStatus.OPEN,
+        symbol='BTCUSDT',
+        side=OrderSide.BUY,
+        order_type=OrderType.MARKET,
+        qty=Decimal('1'),
+        filled_qty=Decimal('1'),
+        price=None,
+    )
+    adapter._venue_trades = [VenueTrade(
+        venue_trade_id='t-1',
+        venue_order_id='v-1',
+        client_order_id='SS-cmd1-00',
+        symbol='BTCUSDT',
+        side=OrderSide.BUY,
+        qty=Decimal('1'),
+        price=Decimal('50000'),
+        fee=Decimal('0.001'),
+        fee_asset='BTC',
+        is_maker=False,
+        timestamp=_CREATED_AT,
+    )]
+
+    await trading._reconcile_account('acc-1')
+
+    events = await spine.read(1)
+    assert len(events) == 1
+    _, event = events[0]
+    assert isinstance(event, FillReceived)
+    assert event.venue_trade_id == 't-1'
+    assert event.trade_id == 'trade-1'
+    state = trading._execution_manager._accounts['acc-1'].trading_state
+    assert ('trade-1', 'acc-1') in state.positions
+    await trading.stop()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_account_emits_terminal_when_venue_is_terminal(
+    spine: EventSpine,
+) -> None:
+    trading, adapter = await _started_trading_with_recon_adapter(spine)
+    order = _make_order()
+    trading._execution_manager._accounts['acc-1'].trading_state.orders['SS-cmd1-00'] = order
+
+    adapter._venue_orders['SS-cmd1-00'] = VenueOrder(
+        venue_order_id='v-1',
+        client_order_id='SS-cmd1-00',
+        status=OrderStatus.CANCELED,
+        symbol='BTCUSDT',
+        side=OrderSide.BUY,
+        order_type=OrderType.MARKET,
+        qty=Decimal('1'),
+        filled_qty=Decimal('0'),
+        price=None,
+    )
+
+    await trading._reconcile_account('acc-1')
+
+    events = await spine.read(1)
+    assert len(events) == 1
+    _, event = events[0]
+    assert isinstance(event, OrderCanceled)
+    assert event.client_order_id == 'SS-cmd1-00'
+    await trading.stop()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_fills_deduplicates(spine: EventSpine) -> None:
+    trading, adapter = await _started_trading_with_recon_adapter(spine)
+    order = _make_order()
+    trading._execution_manager._accounts['acc-1'].trading_state.orders['SS-cmd1-00'] = order
+    trading._execution_manager._command_trade_ids['cmd-1'] = 'trade-1'
+
+    trade = VenueTrade(
+        venue_trade_id='t-1',
+        venue_order_id='v-1',
+        client_order_id='SS-cmd1-00',
+        symbol='BTCUSDT',
+        side=OrderSide.BUY,
+        qty=Decimal('1'),
+        price=Decimal('50000'),
+        fee=Decimal('0.001'),
+        fee_asset='BTC',
+        is_maker=False,
+        timestamp=_CREATED_AT,
+    )
+    adapter._venue_trades = [trade]
+
+    await trading._reconcile_fills('acc-1', order)
+    events_after_first = await spine.read(1)
+    assert len(events_after_first) == 1
+
+    await trading._reconcile_fills('acc-1', order)
+    events_after_second = await spine.read(1)
+    assert len(events_after_second) == 1
+    await trading.stop()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_fills_skips_unknown_account(spine: EventSpine) -> None:
+    trading, _ = await _started_trading_with_recon_adapter(spine)
+
+    order = _make_order()
+    await trading._reconcile_fills('unknown-acc', order)
+
+    events = await spine.read(1)
+    assert len(events) == 0
+    await trading.stop()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_fills_handles_venue_error(spine: EventSpine) -> None:
+    trading, adapter = await _started_trading_with_recon_adapter(spine)
+    order = _make_order()
+    trading._execution_manager._accounts['acc-1'].trading_state.orders['SS-cmd1-00'] = order
+
+    async def fail_trades(
+        account_id: str,
+        symbol: str,
+        *,
+        start_time: datetime | None = None,
+    ) -> list[VenueTrade]:
+        del account_id, symbol, start_time
+        raise VenueError('connection lost')
+
+    adapter.query_trades = fail_trades  # type: ignore[method-assign]
+
+    await trading._reconcile_fills('acc-1', order)
+
+    events = await spine.read(1)
+    assert len(events) == 0
+    await trading.stop()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_fills_skips_mismatched_client_order_id(
+    spine: EventSpine,
+) -> None:
+    trading, adapter = await _started_trading_with_recon_adapter(spine)
+    order = _make_order()
+    trading._execution_manager._accounts['acc-1'].trading_state.orders['SS-cmd1-00'] = order
+    trading._execution_manager._command_trade_ids['cmd-1'] = 'trade-1'
+
+    adapter._venue_trades = [VenueTrade(
+        venue_trade_id='t-1',
+        venue_order_id='v-1',
+        client_order_id='DIFFERENT-ORDER',
+        symbol='BTCUSDT',
+        side=OrderSide.BUY,
+        qty=Decimal('1'),
+        price=Decimal('50000'),
+        fee=Decimal('0.001'),
+        fee_asset='BTC',
+        is_maker=False,
+        timestamp=_CREATED_AT,
+    )]
+
+    await trading._reconcile_fills('acc-1', order)
+
+    events = await spine.read(1)
+    assert len(events) == 0
+    await trading.stop()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_fills_skips_missing_trade_id_mapping(
+    spine: EventSpine,
+) -> None:
+    trading, adapter = await _started_trading_with_recon_adapter(spine)
+    order = _make_order()
+    trading._execution_manager._accounts['acc-1'].trading_state.orders['SS-cmd1-00'] = order
+
+    adapter._venue_trades = [VenueTrade(
+        venue_trade_id='t-1',
+        venue_order_id='v-1',
+        client_order_id='SS-cmd1-00',
+        symbol='BTCUSDT',
+        side=OrderSide.BUY,
+        qty=Decimal('1'),
+        price=Decimal('50000'),
+        fee=Decimal('0.001'),
+        fee_asset='BTC',
+        is_maker=False,
+        timestamp=_CREATED_AT,
+    )]
+
+    await trading._reconcile_fills('acc-1', order)
+
+    events = await spine.read(1)
+    assert len(events) == 0
+    await trading.stop()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_terminal_emits_canceled(spine: EventSpine) -> None:
+    trading, _ = await _started_trading_with_recon_adapter(spine)
+    order = _make_order()
+    venue_order = VenueOrder(
+        venue_order_id='v-1',
+        client_order_id='SS-cmd1-00',
+        status=OrderStatus.CANCELED,
+        symbol='BTCUSDT',
+        side=OrderSide.BUY,
+        order_type=OrderType.MARKET,
+        qty=Decimal('1'),
+        filled_qty=Decimal('0'),
+        price=None,
+    )
+
+    await trading._reconcile_terminal('acc-1', order, venue_order)
+
+    events = await spine.read(1)
+    assert len(events) == 1
+    _, event = events[0]
+    assert isinstance(event, OrderCanceled)
+    await trading.stop()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_terminal_emits_expired(spine: EventSpine) -> None:
+    trading, _ = await _started_trading_with_recon_adapter(spine)
+    order = _make_order()
+    venue_order = VenueOrder(
+        venue_order_id='v-1',
+        client_order_id='SS-cmd1-00',
+        status=OrderStatus.EXPIRED,
+        symbol='BTCUSDT',
+        side=OrderSide.BUY,
+        order_type=OrderType.MARKET,
+        qty=Decimal('1'),
+        filled_qty=Decimal('0'),
+        price=None,
+    )
+
+    await trading._reconcile_terminal('acc-1', order, venue_order)
+
+    events = await spine.read(1)
+    assert len(events) == 1
+    _, event = events[0]
+    assert isinstance(event, OrderExpired)
+    await trading.stop()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_terminal_emits_rejected(spine: EventSpine) -> None:
+    trading, _ = await _started_trading_with_recon_adapter(spine)
+    order = _make_order()
+    venue_order = VenueOrder(
+        venue_order_id='v-1',
+        client_order_id='SS-cmd1-00',
+        status=OrderStatus.REJECTED,
+        symbol='BTCUSDT',
+        side=OrderSide.BUY,
+        order_type=OrderType.MARKET,
+        qty=Decimal('1'),
+        filled_qty=Decimal('0'),
+        price=None,
+    )
+
+    await trading._reconcile_terminal('acc-1', order, venue_order)
+
+    events = await spine.read(1)
+    assert len(events) == 1
+    _, event = events[0]
+    assert isinstance(event, OrderRejected)
+    await trading.stop()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_terminal_skips_non_terminal_venue_status(
+    spine: EventSpine,
+) -> None:
+    trading, _ = await _started_trading_with_recon_adapter(spine)
+    order = _make_order()
+    venue_order = VenueOrder(
+        venue_order_id='v-1',
+        client_order_id='SS-cmd1-00',
+        status=OrderStatus.OPEN,
+        symbol='BTCUSDT',
+        side=OrderSide.BUY,
+        order_type=OrderType.MARKET,
+        qty=Decimal('1'),
+        filled_qty=Decimal('0'),
+        price=None,
+    )
+
+    await trading._reconcile_terminal('acc-1', order, venue_order)
+
+    events = await spine.read(1)
+    assert len(events) == 0
+    await trading.stop()
+
+
+@pytest.mark.asyncio
+async def test_on_execution_report_ignores_non_execution_report(
+    spine: EventSpine,
+) -> None:
+    trading, _ = await _started_trading_with_recon_adapter(spine)
+
+    await trading._on_execution_report('acc-1', {'e': 'outboundAccountPosition'})
+
+    events = await spine.read(1)
+    assert len(events) == 0
+    await trading.stop()
+
+
+@pytest.mark.asyncio
+async def test_on_execution_report_ignores_non_binance_adapter(
+    spine: EventSpine,
+) -> None:
+    trading, _ = await _started_trading_with_recon_adapter(spine)
+
+    await trading._on_execution_report('acc-1', {'e': 'executionReport'})
+
+    events = await spine.read(1)
+    assert len(events) == 0
+    await trading.stop()
+
+
+@pytest.mark.asyncio
+async def test_on_execution_report_skips_unknown_account(
+    spine: EventSpine,
+) -> None:
+    import unittest.mock
+    trading, _ = await _started_trading_with_recon_adapter(spine)
+    trading._venue_adapter = cast(VenueAdapter, unittest.mock.MagicMock(spec=BinanceAdapter))
+
+    await trading._on_execution_report('unknown-acc', {'e': 'executionReport'})
+
+    events = await spine.read(1)
+    assert len(events) == 0
+    await trading.stop()
+
+
+@pytest.mark.asyncio
+async def test_on_execution_report_processes_fill(spine: EventSpine) -> None:
+    import unittest.mock
+    trading, _ = await _started_trading_with_recon_adapter(spine)
+
+    order = _make_order()
+    trading._execution_manager._accounts['acc-1'].trading_state.orders['SS-cmd1-00'] = order
+    trading._execution_manager._command_trade_ids['cmd-1'] = 'trade-1'
+
+    report = ExecutionReport(
+        event_time=_CREATED_AT,
+        symbol='BTCUSDT',
+        client_order_id='SS-cmd1-00',
+        side=OrderSide.BUY,
+        order_type=OrderType.MARKET,
+        original_qty=Decimal('1'),
+        original_price=Decimal('0'),
+        execution_type=ExecutionType.TRADE,
+        order_status=OrderStatus.FILLED,
+        reject_reason='NONE',
+        venue_order_id='v-1',
+        last_filled_qty=Decimal('1'),
+        last_filled_price=Decimal('50000'),
+        cumulative_filled_qty=Decimal('1'),
+        commission=Decimal('0.001'),
+        commission_asset='BTC',
+        transaction_time=_CREATED_AT,
+        venue_trade_id='t-ws-1',
+        is_maker=False,
+    )
+
+    mock_adapter = unittest.mock.MagicMock(spec=BinanceAdapter)
+    mock_adapter.parse_execution_report.return_value = report
+    trading._venue_adapter = cast(VenueAdapter, mock_adapter)
+
+    await trading._on_execution_report('acc-1', {'e': 'executionReport'})
+
+    events = await spine.read(1)
+    assert len(events) == 1
+    _, event = events[0]
+    assert isinstance(event, FillReceived)
+    assert event.venue_trade_id == 't-ws-1'
+    assert event.trade_id == 'trade-1'
+
+    state = trading._execution_manager._accounts['acc-1'].trading_state
+    assert ('trade-1', 'acc-1') in state.positions
+    await trading.stop()
+
+
+@pytest.mark.asyncio
+async def test_on_execution_report_skips_terminal_for_closed_order(
+    spine: EventSpine,
+) -> None:
+    import unittest.mock
+    trading, _ = await _started_trading_with_recon_adapter(spine)
+
+    order = _make_order(status=OrderStatus.FILLED, filled_qty=Decimal('1'))
+    trading._execution_manager._accounts['acc-1'].trading_state.closed_orders['SS-cmd1-00'] = order
+
+    report = ExecutionReport(
+        event_time=_CREATED_AT,
+        symbol='BTCUSDT',
+        client_order_id='SS-cmd1-00',
+        side=OrderSide.BUY,
+        order_type=OrderType.MARKET,
+        original_qty=Decimal('1'),
+        original_price=Decimal('0'),
+        execution_type=ExecutionType.CANCELED,
+        order_status=OrderStatus.CANCELED,
+        reject_reason='NONE',
+        venue_order_id='v-1',
+        last_filled_qty=Decimal('0'),
+        last_filled_price=Decimal('0'),
+        cumulative_filled_qty=Decimal('1'),
+        commission=Decimal('0'),
+        commission_asset=None,
+        transaction_time=_CREATED_AT,
+        venue_trade_id=None,
+        is_maker=False,
+    )
+
+    mock_adapter = unittest.mock.MagicMock(spec=BinanceAdapter)
+    mock_adapter.parse_execution_report.return_value = report
+    trading._venue_adapter = cast(VenueAdapter, mock_adapter)
+
+    await trading._on_execution_report('acc-1', {'e': 'executionReport'})
+
+    events = await spine.read(1)
+    assert len(events) == 0
+    await trading.stop()
+
+
+@pytest.mark.asyncio
+async def test_convert_execution_report_trade(spine: EventSpine) -> None:
+    trading, _ = await _started_trading_with_recon_adapter(spine)
+    order = _make_order()
+    trading._execution_manager._accounts['acc-1'].trading_state.orders['SS-cmd1-00'] = order
+    trading._execution_manager._command_trade_ids['cmd-1'] = 'trade-1'
+
+    report = ExecutionReport(
+        event_time=_CREATED_AT,
+        symbol='BTCUSDT',
+        client_order_id='SS-cmd1-00',
+        side=OrderSide.BUY,
+        order_type=OrderType.MARKET,
+        original_qty=Decimal('1'),
+        original_price=Decimal('0'),
+        execution_type=ExecutionType.TRADE,
+        order_status=OrderStatus.FILLED,
+        reject_reason='NONE',
+        venue_order_id='v-1',
+        last_filled_qty=Decimal('1'),
+        last_filled_price=Decimal('50000'),
+        cumulative_filled_qty=Decimal('1'),
+        commission=Decimal('0.001'),
+        commission_asset='BTC',
+        transaction_time=_CREATED_AT,
+        venue_trade_id='t-1',
+        is_maker=False,
+    )
+
+    event = trading._convert_execution_report('acc-1', report, order)
+    assert isinstance(event, FillReceived)
+    assert event.venue_trade_id == 't-1'
+    assert event.trade_id == 'trade-1'
+    assert event.qty == Decimal('1')
+    assert event.price == Decimal('50000')
+    await trading.stop()
+
+
+@pytest.mark.asyncio
+async def test_convert_execution_report_canceled(spine: EventSpine) -> None:
+    trading, _ = await _started_trading_with_recon_adapter(spine)
+    order = _make_order()
+
+    report = ExecutionReport(
+        event_time=_CREATED_AT,
+        symbol='BTCUSDT',
+        client_order_id='SS-cmd1-00',
+        side=OrderSide.BUY,
+        order_type=OrderType.MARKET,
+        original_qty=Decimal('1'),
+        original_price=Decimal('0'),
+        execution_type=ExecutionType.CANCELED,
+        order_status=OrderStatus.CANCELED,
+        reject_reason='NONE',
+        venue_order_id='v-1',
+        last_filled_qty=Decimal('0'),
+        last_filled_price=Decimal('0'),
+        cumulative_filled_qty=Decimal('0'),
+        commission=Decimal('0'),
+        commission_asset=None,
+        transaction_time=_CREATED_AT,
+        venue_trade_id=None,
+        is_maker=False,
+    )
+
+    event = trading._convert_execution_report('acc-1', report, order)
+    assert isinstance(event, OrderCanceled)
+    assert event.client_order_id == 'SS-cmd1-00'
+    assert event.reason == 'canceled via WebSocket'
+    await trading.stop()
+
+
+@pytest.mark.asyncio
+async def test_convert_execution_report_rejected(spine: EventSpine) -> None:
+    trading, _ = await _started_trading_with_recon_adapter(spine)
+    order = _make_order()
+
+    report = ExecutionReport(
+        event_time=_CREATED_AT,
+        symbol='BTCUSDT',
+        client_order_id='SS-cmd1-00',
+        side=OrderSide.BUY,
+        order_type=OrderType.MARKET,
+        original_qty=Decimal('1'),
+        original_price=Decimal('0'),
+        execution_type=ExecutionType.REJECTED,
+        order_status=OrderStatus.REJECTED,
+        reject_reason='INSUFFICIENT_BALANCE',
+        venue_order_id='v-1',
+        last_filled_qty=Decimal('0'),
+        last_filled_price=Decimal('0'),
+        cumulative_filled_qty=Decimal('0'),
+        commission=Decimal('0'),
+        commission_asset=None,
+        transaction_time=_CREATED_AT,
+        venue_trade_id=None,
+        is_maker=False,
+    )
+
+    event = trading._convert_execution_report('acc-1', report, order)
+    assert isinstance(event, OrderRejected)
+    assert event.reason == 'INSUFFICIENT_BALANCE'
+    await trading.stop()
+
+
+@pytest.mark.asyncio
+async def test_convert_execution_report_expired(spine: EventSpine) -> None:
+    trading, _ = await _started_trading_with_recon_adapter(spine)
+    order = _make_order()
+
+    report = ExecutionReport(
+        event_time=_CREATED_AT,
+        symbol='BTCUSDT',
+        client_order_id='SS-cmd1-00',
+        side=OrderSide.BUY,
+        order_type=OrderType.MARKET,
+        original_qty=Decimal('1'),
+        original_price=Decimal('0'),
+        execution_type=ExecutionType.EXPIRED,
+        order_status=OrderStatus.EXPIRED,
+        reject_reason='NONE',
+        venue_order_id='v-1',
+        last_filled_qty=Decimal('0'),
+        last_filled_price=Decimal('0'),
+        cumulative_filled_qty=Decimal('0'),
+        commission=Decimal('0'),
+        commission_asset=None,
+        transaction_time=_CREATED_AT,
+        venue_trade_id=None,
+        is_maker=False,
+    )
+
+    event = trading._convert_execution_report('acc-1', report, order)
+    assert isinstance(event, OrderExpired)
+    assert event.client_order_id == 'SS-cmd1-00'
+    await trading.stop()
+
+
+@pytest.mark.asyncio
+async def test_convert_execution_report_unknown_type(spine: EventSpine) -> None:
+    trading, _ = await _started_trading_with_recon_adapter(spine)
+    order = _make_order()
+
+    report = ExecutionReport(
+        event_time=_CREATED_AT,
+        symbol='BTCUSDT',
+        client_order_id='SS-cmd1-00',
+        side=OrderSide.BUY,
+        order_type=OrderType.MARKET,
+        original_qty=Decimal('1'),
+        original_price=Decimal('0'),
+        execution_type=ExecutionType.NEW,
+        order_status=OrderStatus.OPEN,
+        reject_reason='NONE',
+        venue_order_id='v-1',
+        last_filled_qty=Decimal('0'),
+        last_filled_price=Decimal('0'),
+        cumulative_filled_qty=Decimal('0'),
+        commission=Decimal('0'),
+        commission_asset=None,
+        transaction_time=_CREATED_AT,
+        venue_trade_id=None,
+        is_maker=False,
+    )
+
+    event = trading._convert_execution_report('acc-1', report, order)
+    assert event is None
+    await trading.stop()
+
+
+@pytest.mark.asyncio
+async def test_convert_execution_report_trade_missing_venue_trade_id(
+    spine: EventSpine,
+) -> None:
+    trading, _ = await _started_trading_with_recon_adapter(spine)
+    order = _make_order()
+    trading._execution_manager._command_trade_ids['cmd-1'] = 'trade-1'
+
+    report = ExecutionReport(
+        event_time=_CREATED_AT,
+        symbol='BTCUSDT',
+        client_order_id='SS-cmd1-00',
+        side=OrderSide.BUY,
+        order_type=OrderType.MARKET,
+        original_qty=Decimal('1'),
+        original_price=Decimal('0'),
+        execution_type=ExecutionType.TRADE,
+        order_status=OrderStatus.FILLED,
+        reject_reason='NONE',
+        venue_order_id='v-1',
+        last_filled_qty=Decimal('1'),
+        last_filled_price=Decimal('50000'),
+        cumulative_filled_qty=Decimal('1'),
+        commission=Decimal('0.001'),
+        commission_asset='BTC',
+        transaction_time=_CREATED_AT,
+        venue_trade_id=None,
+        is_maker=False,
+    )
+
+    event = trading._convert_execution_report('acc-1', report, order)
+    assert event is None
+    await trading.stop()
+
+
+@pytest.mark.asyncio
+async def test_convert_execution_report_trade_missing_commission_asset(
+    spine: EventSpine,
+) -> None:
+    trading, _ = await _started_trading_with_recon_adapter(spine)
+    order = _make_order()
+    trading._execution_manager._command_trade_ids['cmd-1'] = 'trade-1'
+
+    report = ExecutionReport(
+        event_time=_CREATED_AT,
+        symbol='BTCUSDT',
+        client_order_id='SS-cmd1-00',
+        side=OrderSide.BUY,
+        order_type=OrderType.MARKET,
+        original_qty=Decimal('1'),
+        original_price=Decimal('0'),
+        execution_type=ExecutionType.TRADE,
+        order_status=OrderStatus.FILLED,
+        reject_reason='NONE',
+        venue_order_id='v-1',
+        last_filled_qty=Decimal('1'),
+        last_filled_price=Decimal('50000'),
+        cumulative_filled_qty=Decimal('1'),
+        commission=Decimal('0.001'),
+        commission_asset=None,
+        transaction_time=_CREATED_AT,
+        venue_trade_id='t-1',
+        is_maker=False,
+    )
+
+    event = trading._convert_execution_report('acc-1', report, order)
+    assert event is None
+    await trading.stop()
+
+
+@pytest.mark.asyncio
+async def test_convert_execution_report_trade_missing_trade_id_mapping(
+    spine: EventSpine,
+) -> None:
+    trading, _ = await _started_trading_with_recon_adapter(spine)
+    order = _make_order()
+
+    report = ExecutionReport(
+        event_time=_CREATED_AT,
+        symbol='BTCUSDT',
+        client_order_id='SS-cmd1-00',
+        side=OrderSide.BUY,
+        order_type=OrderType.MARKET,
+        original_qty=Decimal('1'),
+        original_price=Decimal('0'),
+        execution_type=ExecutionType.TRADE,
+        order_status=OrderStatus.FILLED,
+        reject_reason='NONE',
+        venue_order_id='v-1',
+        last_filled_qty=Decimal('1'),
+        last_filled_price=Decimal('50000'),
+        cumulative_filled_qty=Decimal('1'),
+        commission=Decimal('0.001'),
+        commission_asset='BTC',
+        transaction_time=_CREATED_AT,
+        venue_trade_id='t-1',
+        is_maker=False,
+    )
+
+    event = trading._convert_execution_report('acc-1', report, order)
+    assert event is None
+    await trading.stop()


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

Removes dead `TradeStatus.PAUSED` enum member (not in RFC, no usage anywhere in codebase) and adds 26 tests covering the two most critical untested MMVP paths identified in the deep audit: startup reconciliation (`_reconcile_account`, `_reconcile_fills`, `_reconcile_terminal`) and WebSocket execution report handling (`_on_execution_report`, `_convert_execution_report`). Bumps version to v0.36.0.

## Checklist

- [x] I have reviewed full diff in "Files changed"
- [x] I left no unnecessary files in the changes
- [x] I ran `python tests/run.py` locally without errors (where applicable)
- [ ] I updated `/docs` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md (unless only docs or other non-code aspect was changed)
- [x] I updated pyproject.toml (unless only docs or other non-code aspect was changed)
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [ ] I linked issue to auto-close on merge (e.g., "Fixes #123") when applicable