### PR TITLE
feat: MMVP-X.2 non-blockers (hydration, validation, perf, encapsulation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -400,18 +400,16 @@
 
 ## v0.38.0 on 7th of April, 2026
 
-- Add nested dataclass hydration to `_coerce` for complex event types in [`event_spine.py`](praxis/infrastructure/event_spine.py)
+- Add nested dataclass hydration to `_coerce` with cached type hints for complex event types in [`event_spine.py`](praxis/infrastructure/event_spine.py)
 - Add `execution_params` validation requiring `SingleShotParams` for `SINGLE_SHOT` mode in [`trade_command.py`](praxis/core/domain/trade_command.py)
 - Add precomputed `_TYPE_HINTS` dict at module load avoiding `get_type_hints()` per-hydration in [`event_spine.py`](praxis/infrastructure/event_spine.py)
 - Add `command_to_order` index to `_AccountRuntime` for O(1) abort order lookup in [`execution_manager.py`](praxis/core/execution_manager.py)
 - Add `_request_with_retry` method extracting retry loop from request methods in [`binance_adapter.py`](praxis/infrastructure/binance_adapter.py)
 - Add `get_trading_state(account_id)` and `trade_id_for_command(command_id)` public accessors in [`execution_manager.py`](praxis/core/execution_manager.py)
-- Add `numpy>=1.26` as runtime dependency for vectorized slippage estimation in [`pyproject.toml`](pyproject.toml)
 - Refactor `_signed_request` and `_api_key_request` to use `_request_with_retry` callable factory in [`binance_adapter.py`](praxis/infrastructure/binance_adapter.py)
-- Refactor `estimate_slippage` to use NumPy vectorized operations (`cumsum`, `searchsorted`, `dot`) in [`estimate_slippage.py`](praxis/core/estimate_slippage.py)
 - Refactor `Trading.start()` event grouping to single-pass `defaultdict` accumulation in [`trading.py`](praxis/trading.py)
 - Refactor `Trading` reconciliation and WebSocket handlers to use public `ExecutionManager` accessors in [`trading.py`](praxis/trading.py)
-- Update WebSocket frame parsing to use `orjson.loads` instead of `json.loads` in [`binance_ws.py`](praxis/infrastructure/binance_ws.py)
-- Remove TD-001, TD-003, TD-005, TD-007, TD-008, TD-010, TD-011, TD-012, TD-015, TD-016 from [`TechnicalDebt.md`](docs/TechnicalDebt.md)
+- Update WebSocket frame parsing to use `orjson.loads` with UTF-8 encoding in [`binance_ws.py`](praxis/infrastructure/binance_ws.py)
+- Remove TD-001, TD-003, TD-005, TD-007, TD-008, TD-010, TD-011, TD-012, TD-016 from [`TechnicalDebt.md`](docs/TechnicalDebt.md)
 - Add nested dataclass hydration test in [`test_event_spine.py`](tests/test_event_spine.py)
 - Add execution_params validation test in [`test_domain_commands.py`](tests/test_domain_commands.py)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -397,3 +397,21 @@
 - Add restart abort test proving abort succeeds after replay in [`test_execution_manager.py`](tests/test_execution_manager.py)
 - Add mutation guard tests for Order and Position in [`test_domain_core.py`](tests/test_domain_core.py)
 - Add VWAP accuracy tests in [`test_trading_state.py`](tests/test_trading_state.py)
+
+## v0.38.0 on 7th of April, 2026
+
+- Add nested dataclass hydration to `_coerce` for complex event types in [`event_spine.py`](praxis/infrastructure/event_spine.py)
+- Add `execution_params` validation requiring `SingleShotParams` for `SINGLE_SHOT` mode in [`trade_command.py`](praxis/core/domain/trade_command.py)
+- Add precomputed `_TYPE_HINTS` dict at module load avoiding `get_type_hints()` per-hydration in [`event_spine.py`](praxis/infrastructure/event_spine.py)
+- Add `command_to_order` index to `_AccountRuntime` for O(1) abort order lookup in [`execution_manager.py`](praxis/core/execution_manager.py)
+- Add `_request_with_retry` method extracting retry loop from request methods in [`binance_adapter.py`](praxis/infrastructure/binance_adapter.py)
+- Add `get_trading_state(account_id)` and `trade_id_for_command(command_id)` public accessors in [`execution_manager.py`](praxis/core/execution_manager.py)
+- Add `numpy>=1.26` as runtime dependency for vectorized slippage estimation in [`pyproject.toml`](pyproject.toml)
+- Refactor `_signed_request` and `_api_key_request` to use `_request_with_retry` callable factory in [`binance_adapter.py`](praxis/infrastructure/binance_adapter.py)
+- Refactor `estimate_slippage` to use NumPy vectorized operations (`cumsum`, `searchsorted`, `dot`) in [`estimate_slippage.py`](praxis/core/estimate_slippage.py)
+- Refactor `Trading.start()` event grouping to single-pass `defaultdict` accumulation in [`trading.py`](praxis/trading.py)
+- Refactor `Trading` reconciliation and WebSocket handlers to use public `ExecutionManager` accessors in [`trading.py`](praxis/trading.py)
+- Update WebSocket frame parsing to use `orjson.loads` instead of `json.loads` in [`binance_ws.py`](praxis/infrastructure/binance_ws.py)
+- Remove TD-001, TD-003, TD-005, TD-007, TD-008, TD-010, TD-011, TD-012, TD-015, TD-016 from [`TechnicalDebt.md`](docs/TechnicalDebt.md)
+- Add nested dataclass hydration test in [`test_event_spine.py`](tests/test_event_spine.py)
+- Add execution_params validation test in [`test_domain_commands.py`](tests/test_domain_commands.py)

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -17,19 +17,6 @@ Known technical debt in shipped code. Each item includes origin PR, severity, an
 
 ---
 
-## TD-003: TradeCommand.execution_params not validated against execution_mode
-
-**Origin**: PR #25 (review comments)
-**Severity**: Low (only `SINGLE_SHOT` mode exists)
-**Module**: `praxis/core/domain/trade_command.py`
-
-`execution_params` is typed as `SingleShotParams` but `execution_mode` accepts any `ExecutionMode` enum value. A `TradeCommand` with `execution_mode=TWAP` and `SingleShotParams` is accepted without error.
-
-**When to fix**: Before adding a second execution mode.
-**Migration**: Widen `execution_params` to a union or protocol type and validate that the params type matches the selected mode in `__post_init__`.
-
----
-
 ## TD-004: FillReceived append atomicity relies on caller discipline
 
 **Origin**: PR #31 (review comments)

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -30,19 +30,6 @@ Known technical debt in shipped code. Each item includes origin PR, severity, an
 
 ---
 
-## TD-005: _hydrate calls get_type_hints per row on every read
-
-**Origin**: PR #31 (review comments)
-**Severity**: Low (epochs are small currently)
-**Module**: `praxis/infrastructure/event_spine.py`
-
-`_hydrate()` calls `get_type_hints(cls)` for every row returned by `read()`. This is repeated reflection work that scales linearly with epoch size and incurs significant overhead during startup/replay. For large epochs the cost dominates `read()` time.
-
-**When to fix**: Before epochs grow to thousands of events.
-**Migration**: Precompute a `{event_type: hints}` map alongside `_EVENT_REGISTRY` at module load time and reuse it in `_hydrate`.
-
----
-
 ## TD-007: Duplicated retry loop in _signed_request and _api_key_request
 
 **Origin**: §2.9 implementation

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -4,19 +4,6 @@ Known technical debt in shipped code. Each item includes origin PR, severity, an
 
 ---
 
-## TD-001: EventSpine hydration assumes flat event dataclasses
-
-**Origin**: PR #30 (review by @mikkokotila)
-**Severity**: Low (all events are currently flat)
-**Module**: `praxis/infrastructure/event_spine.py`
-
-`dataclasses.asdict()` recursively converts nested dataclasses into plain dicts. `_hydrate` reconstructs only top-level fields via `get_type_hints`. If any event ever contains a nested dataclass, the round-trip will silently produce a dict where a dataclass is expected.
-
-**When to fix**: Before adding nested dataclass fields to any event type.
-**Migration**: Add nested-type detection in `_hydrate` that recursively reconstructs inner dataclasses from their dict representation.
-
----
-
 ## TD-002: Mutable domain models lack post-construction invariant guards
 
 **Origin**: PR #24 (review comments)

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -82,19 +82,6 @@ RFC §6.2 defines walk-the-book slippage with mid-price as the primary benchmark
 
 ---
 
-## TD-012: Event filtering is O(accounts × events) during startup
-
-**Origin**: PR #59 (Copilot review)
-**Severity**: Low (epochs and accounts are small currently)
-**Module**: `praxis/trading.py`
-
-`Trading.start()` reads the full epoch and then scans it for each account with a list comprehension. This is O(events × accounts) and can become costly as epochs/accounts grow, creating a significant bottleneck during replay.
-
-**When to fix**: Before epochs grow to thousands of events or account counts increase significantly.
-**Migration**: Group events by `account_id` in a single pass (e.g., build a `dict[account_id, list[(seq, event)]]`) before the loop, or add an EventSpine query that reads only events for a given account.
-
----
-
 ## TD-013: replay_events lacks command context for abort processing
 
 **Origin**: PR #59 (Copilot review)

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -43,32 +43,6 @@ Known technical debt in shipped code. Each item includes origin PR, severity, an
 
 ---
 
-## TD-010: No venue LTP benchmark support for slippage analytics
-
-**Origin**: §6.2 assessment follow-up
-**Severity**: Low (RFC primary benchmark is mid-price)
-**Module**: `praxis/core/execution_manager.py`, `praxis/infrastructure/venue_adapter.py`
-
-RFC §6.2 defines walk-the-book slippage with mid-price as the primary benchmark and `reference_price` as supplementary. Praxis currently has no Venue Adapter API for last traded price (LTP), so slippage analytics cannot include a venue-LTP benchmark without caller-supplied price data.
-
-**When to fix**: If Manager or analytics consumers require venue-native LTP-based slippage benchmarking.
-**Migration**: Add a venue-agnostic LTP query method to `VenueAdapter` (with Binance implementation), compute and log optional LTP-based slippage metric alongside existing mid-price and reference-price metrics.
-
----
-
-## TD-011: Trading accesses ExecutionManager private attributes
-
-**Origin**: PR #59 (Copilot review)
-**Severity**: Low (single consumer)
-**Module**: `praxis/trading.py`
-
-`Trading` accesses `ExecutionManager._accounts` and `_command_trade_ids` directly for reconciliation and WebSocket handling. This tight coupling makes future refactors risky.
-
-**When to fix**: Before adding additional consumers of ExecutionManager internals.
-**Migration**: Add small public accessors on ExecutionManager (e.g., `get_trading_state(account_id)`, `trade_id_for_command(command_id)`) and use those instead of reaching into private attributes.
-
----
-
 ## TD-013: replay_events lacks command context for abort processing
 
 **Origin**: PR #59 (Copilot review)

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -43,19 +43,6 @@ Known technical debt in shipped code. Each item includes origin PR, severity, an
 
 ---
 
-## TD-008: Linear order scan in _process_abort
-
-**Origin**: PR #52 (Copilot review)
-**Severity**: Low (typically 1-2 orders per account)
-**Module**: `praxis/core/execution_manager.py`
-
-`_process_abort` iterates `runtime.trading_state.orders` to find the order matching `abort.command_id`. This is O(n) in the number of open orders. As per performance audit, this creates an O(N) search bottleneck that scales with the number of open orders.
-
-**When to fix**: When multi-slice modes (TWAP, ICEBERG) are implemented and order counts per account grow.
-**Migration**: Add a `command_id → client_order_id` index in `_AccountRuntime` populated by `_process_command` on order submission, enabling O(1) lookup in `_process_abort`.
-
----
-
 ## TD-009: VWAP re-read from spine on abort
 
 **Origin**: PR #52 (Copilot review)

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -108,19 +108,6 @@ The RFC establishes a single-writer model where all `TradingState` mutations flo
 
 ---
 
-## TD-015: Walk-the-book slippage is a pure Python loop
-
-**Origin**: Performance audit
-**Severity**: Medium (O(depth) complexity, scales with book granularity)
-**Module**: `praxis/core/estimate_slippage.py`
-
-The slippage estimation logic iterates over order book levels in a `for` loop. While currently limited to 20 levels, this will become a bottleneck for high-frequency strategies or when processing full book depth.
-
-**When to fix**: Before high-frequency execution or when depth limits exceed 100 levels.
-**Migration**: Replace the `for` loop with vectorized NumPy operations (e.g., `cumsum` for depth accumulation and `searchsorted` for target quantity lookup).
-
----
-
 ## TD-016: binance_ws uses standard json.loads
 
 **Origin**: Performance audit

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -30,19 +30,6 @@ Known technical debt in shipped code. Each item includes origin PR, severity, an
 
 ---
 
-## TD-007: Duplicated retry loop in _signed_request and _api_key_request
-
-**Origin**: §2.9 implementation
-**Severity**: Low (two copies, no third expected)
-**Module**: `praxis/infrastructure/binance_adapter.py`
-
-`_signed_request` and `_api_key_request` share ~80 lines of identical retry/backoff/rate-limit logic. The only difference is URL construction (HMAC-signed query string vs plain params). This is manageable at two copies but would become a maintenance risk if a third request style is added.
-
-**When to fix**: Before adding a third request method variant, or during post-WP-0003 cleanup.
-**Migration**: Extract a `_request_with_retry(method, path, *, build_request, account_id)` that owns the retry loop, and have both methods delegate to it.
-
----
-
 ## TD-009: VWAP re-read from spine on abort
 
 **Origin**: PR #52 (Copilot review)

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -106,15 +106,3 @@ The RFC establishes a single-writer model where all `TradingState` mutations flo
 **When to fix**: Before multi-account support or any path where fills and reconciliation can overlap.
 **Migration**: Route WS fills and reconciliation results through the account coroutine's command queue so all state mutations are serialized through the single-writer.
 
----
-
-## TD-016: binance_ws uses standard json.loads
-
-**Origin**: Performance audit
-**Severity**: Low (impacts ingestion latency)
-**Module**: `praxis/infrastructure/binance_ws.py`
-
-The WebSocket ingestion loop uses standard `json.loads` for frame parsing. Given high-frequency WebSocket updates, this adds unnecessary overhead compared to `orjson`.
-
-**When to fix**: Before low-latency execution requirements.
-**Migration**: Switch to `orjson.loads` for WebSocket frame parsing, consistent with `EventSpine`.

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -67,3 +67,16 @@ The RFC establishes a single-writer model where all `TradingState` mutations flo
 **When to fix**: Before multi-account support or any path where fills and reconciliation can overlap.
 **Migration**: Route WS fills and reconciliation results through the account coroutine's command queue so all state mutations are serialized through the single-writer.
 
+---
+
+## TD-015: Slippage estimation scales linearly with book depth
+
+**Origin**: PR #66 (review comments)
+**Severity**: Low (depth typically ~20 levels, Decimal loop is fast)
+**Module**: `praxis/core/estimate_slippage.py`
+
+`estimate_slippage()` walks the order book level-by-level with Decimal arithmetic. For current depth limits (~20 levels), this is fast. NumPy vectorization was attempted but rejected due to precision loss (float64 cannot represent all Decimal values exactly) and disproportionate dependency overhead (~30MB for ~20 levels).
+
+**When to fix**: Before depth limits exceed 100 levels.
+**Migration**: If performance becomes an issue, consider Decimal-native cumulative precomputation or early-exit optimizations. Do not use float64 for financial calculations.
+

--- a/praxis/core/domain/trade_command.py
+++ b/praxis/core/domain/trade_command.py
@@ -86,3 +86,10 @@ class TradeCommand:
         if self.created_at.tzinfo is None or self.created_at.utcoffset() is None:
             msg = 'TradeCommand.created_at must be timezone-aware'
             raise ValueError(msg)
+
+        if (
+            self.execution_mode is ExecutionMode.SINGLE_SHOT
+            and not isinstance(self.execution_params, SingleShotParams)
+        ):
+            msg = 'execution_params must be SingleShotParams for SINGLE_SHOT mode'
+            raise TypeError(msg)

--- a/praxis/core/estimate_slippage.py
+++ b/praxis/core/estimate_slippage.py
@@ -11,6 +11,8 @@ import logging
 from dataclasses import dataclass
 from decimal import Decimal
 
+import numpy as np
+
 from praxis.core.domain.enums import OrderSide
 from praxis.infrastructure.venue_adapter import OrderBookSnapshot
 
@@ -76,31 +78,40 @@ def estimate_slippage(
         return None
 
     levels = book.asks if side == OrderSide.BUY else book.bids
-    remaining = qty
-    cost = _ZERO
 
-    for level in levels:
-        if remaining <= _ZERO:
-            break
-        fill_qty = min(remaining, level.qty)
-        cost += fill_qty * level.price
-        remaining -= fill_qty
+    prices = np.array([float(level.price) for level in levels], dtype=np.float64)
+    qtys = np.array([float(level.qty) for level in levels], dtype=np.float64)
+    target = float(qty)
 
-    filled = qty - remaining
+    cumulative = np.cumsum(qtys)
+    idx = np.searchsorted(cumulative, target, side='left')
 
-    if filled == _ZERO:
+    if idx == 0:
+        fill_qty = min(target, qtys[0])
+        cost = fill_qty * prices[0]
+        filled = fill_qty
+    elif idx >= len(qtys):
+        cost = float(np.dot(prices, qtys))
+        filled = cumulative[-1]
+    else:
+        full_cost = float(np.dot(prices[:idx], qtys[:idx]))
+        partial_qty = target - cumulative[idx - 1]
+        cost = full_cost + partial_qty * prices[idx]
+        filled = target
+
+    if filled == 0:
         return None
 
-    if remaining > _ZERO:
+    if filled < target:
         _log.warning(
             'book depth insufficient: symbol=%s needed=%s available=%s side=%s',
             symbol,
             qty,
-            filled,
+            Decimal(str(filled)),
             side.value,
         )
 
-    simulated_vwap = cost / filled
+    simulated_vwap = Decimal(str(cost / filled))
     slippage_bps = (simulated_vwap - mid_price) / mid_price * _BPS_MULTIPLIER
 
     return SlippageEstimate(

--- a/praxis/core/estimate_slippage.py
+++ b/praxis/core/estimate_slippage.py
@@ -81,6 +81,10 @@ def estimate_slippage(
 
     prices = np.array([float(level.price) for level in levels], dtype=np.float64)
     qtys = np.array([float(level.qty) for level in levels], dtype=np.float64)
+
+    if len(qtys) == 0:
+        return None
+
     target = float(qty)
 
     cumulative = np.cumsum(qtys)

--- a/praxis/core/estimate_slippage.py
+++ b/praxis/core/estimate_slippage.py
@@ -11,8 +11,6 @@ import logging
 from dataclasses import dataclass
 from decimal import Decimal
 
-import numpy as np
-
 from praxis.core.domain.enums import OrderSide
 from praxis.infrastructure.venue_adapter import OrderBookSnapshot
 
@@ -78,44 +76,31 @@ def estimate_slippage(
         return None
 
     levels = book.asks if side == OrderSide.BUY else book.bids
+    remaining = qty
+    cost = _ZERO
 
-    prices = np.array([float(level.price) for level in levels], dtype=np.float64)
-    qtys = np.array([float(level.qty) for level in levels], dtype=np.float64)
+    for level in levels:
+        if remaining <= _ZERO:
+            break
+        fill_qty = min(remaining, level.qty)
+        cost += fill_qty * level.price
+        remaining -= fill_qty
 
-    if len(qtys) == 0:
+    filled = qty - remaining
+
+    if filled == _ZERO:
         return None
 
-    target = float(qty)
-
-    cumulative = np.cumsum(qtys)
-    idx = np.searchsorted(cumulative, target, side='left')
-
-    if idx == 0:
-        fill_qty = min(target, qtys[0])
-        cost = fill_qty * prices[0]
-        filled = fill_qty
-    elif idx >= len(qtys):
-        cost = float(np.dot(prices, qtys))
-        filled = cumulative[-1]
-    else:
-        full_cost = float(np.dot(prices[:idx], qtys[:idx]))
-        partial_qty = target - cumulative[idx - 1]
-        cost = full_cost + partial_qty * prices[idx]
-        filled = target
-
-    if filled == 0:
-        return None
-
-    if filled < target:
+    if remaining > _ZERO:
         _log.warning(
             'book depth insufficient: symbol=%s needed=%s available=%s side=%s',
             symbol,
             qty,
-            Decimal(str(filled)),
+            filled,
             side.value,
         )
 
-    simulated_vwap = Decimal(str(cost / filled))
+    simulated_vwap = cost / filled
     slippage_bps = (simulated_vwap - mid_price) / mid_price * _BPS_MULTIPLIER
 
     return SlippageEstimate(

--- a/praxis/core/execution_manager.py
+++ b/praxis/core/execution_manager.py
@@ -99,6 +99,7 @@ class _AccountRuntime:
         self.ws_event_queue = ws_event_queue
         self.trading_state = trading_state
         self.task: asyncio.Task[None] | None = None
+        self.command_to_order: dict[str, str] = {}
 
 
 class ExecutionManager:
@@ -263,6 +264,7 @@ class ExecutionManager:
 
             if isinstance(event, OrderSubmitIntent):
                 self._command_trade_ids[event.command_id] = event.trade_id
+                runtime.command_to_order[event.command_id] = event.client_order_id
 
     def pull_positions(self, account_id: str) -> dict[tuple[str, str], Position]:
         '''
@@ -675,6 +677,7 @@ class ExecutionManager:
         )
         await self._event_spine.append(intent, self._epoch_id)
         runtime.trading_state.apply(intent)
+        runtime.command_to_order[cmd.command_id] = client_order_id
 
         try:
             result = await self._venue_adapter.submit_order(
@@ -879,15 +882,14 @@ class ExecutionManager:
             )
             return None
 
-        order: Order | None = None
-        client_order_id: str | None = None
-        for coid, o in runtime.trading_state.orders.items():
-            if o.command_id == abort.command_id:
-                order = o
-                client_order_id = coid
-                break
+        client_order_id = runtime.command_to_order.get(abort.command_id)
+        order = (
+            runtime.trading_state.orders.get(client_order_id)
+            if client_order_id
+            else None
+        )
 
-        if order is None or client_order_id is None:
+        if order is None:
             if abort.command_id in self._accepted_commands:
                 self._aborted_commands[abort.command_id] = abort.reason
                 _log.info(

--- a/praxis/core/execution_manager.py
+++ b/praxis/core/execution_manager.py
@@ -290,6 +290,33 @@ class ExecutionManager:
             for key, position in runtime.trading_state.positions.items()
         }
 
+    def get_trading_state(self, account_id: str) -> TradingState | None:
+        '''
+        Return the TradingState for a registered account.
+
+        Args:
+            account_id (str): Account identifier to query.
+
+        Returns:
+            TradingState | None: Trading state or None if not registered.
+        '''
+
+        runtime = self._accounts.get(account_id)
+        return runtime.trading_state if runtime is not None else None
+
+    def trade_id_for_command(self, command_id: str) -> str | None:
+        '''
+        Return the trade_id associated with a command_id.
+
+        Args:
+            command_id (str): Command identifier to look up.
+
+        Returns:
+            str | None: Trade identifier or None if not found.
+        '''
+
+        return self._command_trade_ids.get(command_id)
+
     def _deadline_at(self, cmd: TradeCommand) -> datetime:
         '''
         Compute the absolute deadline timestamp for a command.

--- a/praxis/core/execution_manager.py
+++ b/praxis/core/execution_manager.py
@@ -958,7 +958,7 @@ class ExecutionManager:
             canceled = OrderCanceled(
                 account_id=order.account_id,
                 timestamp=datetime.now(timezone.utc),
-                client_order_id=client_order_id,
+                client_order_id=order.client_order_id,
                 venue_order_id=venue_order_id,
                 reason=abort.reason,
             )

--- a/praxis/infrastructure/binance_adapter.py
+++ b/praxis/infrastructure/binance_adapter.py
@@ -16,7 +16,8 @@ import logging
 import math
 import random
 import time
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
+from contextlib import AbstractAsyncContextManager
 from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Any
@@ -322,6 +323,82 @@ class BinanceAdapter:
         ).hexdigest()
         return f'{query}&signature={signature}'
 
+    async def _request_with_retry(
+        self,
+        method: str,
+        path: str,
+        account_id: str,
+        build_request: Callable[[], AbstractAsyncContextManager[aiohttp.ClientResponse]],
+    ) -> Any:
+
+        '''
+        Execute an HTTP request with retry logic.
+
+        Args:
+            method (str): HTTP method for logging
+            path (str): API endpoint path for logging
+            account_id (str): Account identifier for weight tracking
+            build_request (Callable): Factory returning async context manager for the request
+
+        Returns:
+            Any: Parsed JSON response body
+
+        Raises:
+            TransientError: After all retry attempts are exhausted
+            RateLimitError: On non-429 rate limit responses, or after retry exhaustion
+        '''
+
+        last_error: TransientError | None = None
+
+        for attempt in range(_MAX_RETRIES):
+            try:
+                async with build_request() as response:
+                    self._update_weight_from_headers(response, account_id)
+                    await self._raise_on_error(response)
+                    data: Any = await response.json()
+                    return data
+            except TransientError as exc:
+                last_error = exc
+                if attempt + 1 == _MAX_RETRIES:
+                    break
+                delay = random.uniform(0, _RETRY_BASE_DELAY * 2 ** attempt)
+                _log.warning(
+                    'Transient error on %s %s (attempt %d/%d), retrying in %.2fs: %s',
+                    method, path, attempt + 1, _MAX_RETRIES, delay, exc,
+                )
+                await asyncio.sleep(delay)
+            except RateLimitError as exc:
+                if attempt + 1 == _MAX_RETRIES or exc.status_code != _HTTP_TOO_MANY:
+                    raise
+                delay = max(0.0, exc.retry_after) if exc.retry_after is not None else random.uniform(0, _RETRY_BASE_DELAY * 2 ** attempt)
+                _log.warning(
+                    'Rate limited on %s %s (attempt %d/%d), retrying in %.2fs',
+                    method, path, attempt + 1, _MAX_RETRIES, delay,
+                )
+                await asyncio.sleep(delay)
+            except VenueError:
+                raise
+            except (aiohttp.ClientError, TimeoutError, ValueError) as exc:
+                msg = f"Request failed: {exc}"
+                last_error = TransientError(msg)
+                last_error.__cause__ = exc
+                if attempt + 1 == _MAX_RETRIES:
+                    break
+                delay = random.uniform(0, _RETRY_BASE_DELAY * 2 ** attempt)
+                _log.warning(
+                    'Transport error on %s %s (attempt %d/%d), retrying in %.2fs: %s',
+                    method, path, attempt + 1, _MAX_RETRIES, delay, exc,
+                )
+                await asyncio.sleep(delay)
+
+        _log.error(
+            'All %d attempts exhausted on %s %s: %s',
+            _MAX_RETRIES, method, path, last_error,
+        )
+        if last_error is None:
+            raise TransientError(f"All {_MAX_RETRIES} attempts exhausted on {method} {path}")
+        raise last_error
+
     async def _signed_request(
         self,
         method: str,
@@ -356,62 +433,16 @@ class BinanceAdapter:
         session = await self._ensure_session()
         api_key, api_secret = self._get_credentials(account_id)
         headers = {_API_KEY_HEADER: api_key}
-        last_error: TransientError | None = None
 
-        for attempt in range(_MAX_RETRIES):
+        def build_request() -> AbstractAsyncContextManager[aiohttp.ClientResponse]:
             query_string = self._sign_params(params, api_secret)
+            return session.request(
+                method,
+                f"{self._base_url}{path}?{query_string}",
+                headers=headers,
+            )
 
-            try:
-                async with session.request(
-                    method,
-                    f"{self._base_url}{path}?{query_string}",
-                    headers=headers,
-                ) as response:
-                    self._update_weight_from_headers(response, account_id)
-                    await self._raise_on_error(response)
-                    data: Any = await response.json()
-                    return data
-            except TransientError as exc:
-                last_error = exc
-                if attempt + 1 == _MAX_RETRIES:
-                    break
-                delay = random.uniform(0, _RETRY_BASE_DELAY * 2 ** attempt)
-                _log.warning(
-                    'Transient error on %s %s (attempt %d/%d), retrying in %.2fs: %s',
-                    method, path, attempt + 1, _MAX_RETRIES, delay, exc,
-                )
-                await asyncio.sleep(delay)
-            except RateLimitError as exc:
-                if attempt + 1 == _MAX_RETRIES or exc.status_code != _HTTP_TOO_MANY:
-                    raise
-                delay = max(0.0, exc.retry_after) if exc.retry_after is not None else random.uniform(0, _RETRY_BASE_DELAY * 2 ** attempt)
-                _log.warning(
-                    'Rate limited on %s %s (attempt %d/%d), retrying in %.2fs',
-                    method, path, attempt + 1, _MAX_RETRIES, delay,
-                )
-                await asyncio.sleep(delay)
-            except VenueError:
-                raise
-            except (aiohttp.ClientError, TimeoutError, ValueError) as exc:
-                msg = f"Request failed: {exc}"
-                last_error = TransientError(msg)
-                last_error.__cause__ = exc
-                if attempt + 1 == _MAX_RETRIES:
-                    break
-                delay = random.uniform(0, _RETRY_BASE_DELAY * 2 ** attempt)
-                _log.warning(
-                    'Transport error on %s %s (attempt %d/%d), retrying in %.2fs: %s',
-                    method, path, attempt + 1, _MAX_RETRIES, delay, exc,
-                )
-                await asyncio.sleep(delay)
-
-        _log.error(
-            'All %d attempts exhausted on %s %s: %s',
-            _MAX_RETRIES, method, path, last_error,
-        )
-        if last_error is None:
-            raise TransientError(f"All {_MAX_RETRIES} attempts exhausted on {method} {path}")
-        raise last_error
+        return await self._request_with_retry(method, path, account_id, build_request)
 
     async def _api_key_request(
         self,
@@ -446,61 +477,16 @@ class BinanceAdapter:
         session = await self._ensure_session()
         api_key, _ = self._get_credentials(account_id)
         headers = {_API_KEY_HEADER: api_key}
-        last_error: TransientError | None = None
 
-        for attempt in range(_MAX_RETRIES):
-            try:
-                async with session.request(
-                    method,
-                    f"{self._base_url}{path}",
-                    params=params,
-                    headers=headers,
-                ) as response:
-                    self._update_weight_from_headers(response, account_id)
-                    await self._raise_on_error(response)
-                    data: Any = await response.json()
-                    return data
-            except TransientError as exc:
-                last_error = exc
-                if attempt + 1 == _MAX_RETRIES:
-                    break
-                delay = random.uniform(0, _RETRY_BASE_DELAY * 2 ** attempt)
-                _log.warning(
-                    'Transient error on %s %s (attempt %d/%d), retrying in %.2fs: %s',
-                    method, path, attempt + 1, _MAX_RETRIES, delay, exc,
-                )
-                await asyncio.sleep(delay)
-            except RateLimitError as exc:
-                if attempt + 1 == _MAX_RETRIES or exc.status_code != _HTTP_TOO_MANY:
-                    raise
-                delay = max(0.0, exc.retry_after) if exc.retry_after is not None else random.uniform(0, _RETRY_BASE_DELAY * 2 ** attempt)
-                _log.warning(
-                    'Rate limited on %s %s (attempt %d/%d), retrying in %.2fs',
-                    method, path, attempt + 1, _MAX_RETRIES, delay,
-                )
-                await asyncio.sleep(delay)
-            except VenueError:
-                raise
-            except (aiohttp.ClientError, TimeoutError, ValueError) as exc:
-                msg = f"Request failed: {exc}"
-                last_error = TransientError(msg)
-                last_error.__cause__ = exc
-                if attempt + 1 == _MAX_RETRIES:
-                    break
-                delay = random.uniform(0, _RETRY_BASE_DELAY * 2 ** attempt)
-                _log.warning(
-                    'Transport error on %s %s (attempt %d/%d), retrying in %.2fs: %s',
-                    method, path, attempt + 1, _MAX_RETRIES, delay, exc,
-                )
-                await asyncio.sleep(delay)
+        def build_request() -> AbstractAsyncContextManager[aiohttp.ClientResponse]:
+            return session.request(
+                method,
+                f"{self._base_url}{path}",
+                params=params,
+                headers=headers,
+            )
 
-        _log.error(
-            'All %d attempts exhausted on %s %s: %s',
-            _MAX_RETRIES, method, path, last_error,
-        )
-        if last_error is None:
-            raise TransientError(f"All {_MAX_RETRIES} attempts exhausted on {method} {path}")
-        raise last_error
+        return await self._request_with_retry(method, path, account_id, build_request)
 
     async def _create_listen_key(self, account_id: str) -> str:
 

--- a/praxis/infrastructure/binance_ws.py
+++ b/praxis/infrastructure/binance_ws.py
@@ -9,13 +9,13 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import json
 import logging
 import random
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any
 
 import aiohttp
+import orjson
 
 from praxis.infrastructure.venue_adapter import VenueError
 
@@ -303,8 +303,8 @@ class BinanceUserStream:
         async for msg in self._ws:
             if msg.type == aiohttp.WSMsgType.TEXT:
                 try:
-                    data = json.loads(msg.data)
-                except json.JSONDecodeError:
+                    data = orjson.loads(msg.data)
+                except orjson.JSONDecodeError:
                     _log.warning('non-JSON frame: %s', msg.data[:200])
                     continue
                 try:

--- a/praxis/infrastructure/binance_ws.py
+++ b/praxis/infrastructure/binance_ws.py
@@ -303,7 +303,7 @@ class BinanceUserStream:
         async for msg in self._ws:
             if msg.type == aiohttp.WSMsgType.TEXT:
                 try:
-                    data = orjson.loads(msg.data)
+                    data = orjson.loads(msg.data.encode('utf-8'))
                 except orjson.JSONDecodeError:
                     _log.warning('non-JSON frame: %s', msg.data[:200])
                     continue

--- a/praxis/infrastructure/event_spine.py
+++ b/praxis/infrastructure/event_spine.py
@@ -133,16 +133,19 @@ def _coerce(value: Any, target: type) -> Any:
         args = [a for a in get_args(target) if a is not type(None)]
         return _coerce(value, args[0]) if args else value
 
+    result = value
     if target is Decimal:
-        return Decimal(str(value))
+        result = Decimal(str(value))
+    elif target is datetime:
+        result = datetime.fromisoformat(str(value))
+    elif isinstance(target, type) and issubclass(target, enum.Enum):
+        result = target(value)
+    elif dataclasses.is_dataclass(target) and isinstance(value, dict):
+        hints = get_type_hints(target)
+        coerced = {k: _coerce(v, hints[k]) for k, v in value.items() if k in hints}
+        result = target(**coerced)
 
-    if target is datetime:
-        return datetime.fromisoformat(str(value))
-
-    if isinstance(target, type) and issubclass(target, enum.Enum):
-        return target(value)
-
-    return value
+    return result
 
 
 def _hydrate(event_type: str, payload: bytes) -> Event:

--- a/praxis/infrastructure/event_spine.py
+++ b/praxis/infrastructure/event_spine.py
@@ -93,6 +93,10 @@ _EVENT_REGISTRY: dict[str, type] = {
     )
 }
 
+_TYPE_HINTS: dict[str, dict[str, type]] = {
+    name: get_type_hints(cls) for name, cls in _EVENT_REGISTRY.items()
+}
+
 
 def _serialize_default(obj: Any) -> Any:
 
@@ -166,7 +170,7 @@ def _hydrate(event_type: str, payload: bytes) -> Event:
         msg = f"Unknown event_type: {event_type!r}"
         raise ValueError(msg)
     raw: dict[str, Any] = orjson.loads(payload)
-    hints = get_type_hints(cls)
+    hints = _TYPE_HINTS[event_type]
     coerced = {k: _coerce(v, hints[k]) for k, v in raw.items() if k in hints}
     return cls(**coerced)  # type: ignore[no-any-return]
 

--- a/praxis/infrastructure/event_spine.py
+++ b/praxis/infrastructure/event_spine.py
@@ -93,9 +93,11 @@ _EVENT_REGISTRY: dict[str, type] = {
     )
 }
 
-_TYPE_HINTS: dict[str, dict[str, type]] = {
+_TYPE_HINTS: dict[str, dict[str, Any]] = {
     name: get_type_hints(cls) for name, cls in _EVENT_REGISTRY.items()
 }
+
+_NESTED_TYPE_HINTS: dict[type, dict[str, Any]] = {}
 
 
 def _serialize_default(obj: Any) -> Any:
@@ -145,7 +147,9 @@ def _coerce(value: Any, target: type) -> Any:
     elif isinstance(target, type) and issubclass(target, enum.Enum):
         result = target(value)
     elif dataclasses.is_dataclass(target) and isinstance(value, dict):
-        hints = get_type_hints(target)
+        if target not in _NESTED_TYPE_HINTS:
+            _NESTED_TYPE_HINTS[target] = get_type_hints(target)
+        hints = _NESTED_TYPE_HINTS[target]
         coerced = {k: _coerce(v, hints[k]) for k, v in value.items() if k in hints}
         result = target(**coerced)
 

--- a/praxis/trading.py
+++ b/praxis/trading.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections import defaultdict
 from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Any, cast
@@ -136,15 +137,15 @@ class Trading:
 
         all_events = await self._event_spine.read(self._config.epoch_id)
 
+        events_by_account: dict[str, list[tuple[int, Event]]] = defaultdict(list)
+        for seq, event in all_events:
+            events_by_account[event.account_id].append((seq, event))
+
         try:
             for account_id in self._config.account_credentials:
                 self._inbound.register_account(account_id)
                 self._managed_accounts.add(account_id)
-                account_events = [
-                    (seq, event) for seq, event in all_events
-                    if event.account_id == account_id
-                ]
-                await self._startup_account(account_id, account_events)
+                await self._startup_account(account_id, events_by_account[account_id])
         except Exception:
             await self._cleanup_partial_startup()
             raise

--- a/praxis/trading.py
+++ b/praxis/trading.py
@@ -137,7 +137,7 @@ class Trading:
 
         all_events = await self._event_spine.read(self._config.epoch_id)
 
-        events_by_account: dict[str, list[tuple[int, Event]]] = defaultdict(list)
+        events_by_account: defaultdict[str, list[tuple[int, Event]]] = defaultdict(list)
         for seq, event in all_events:
             events_by_account[event.account_id].append((seq, event))
 

--- a/praxis/trading.py
+++ b/praxis/trading.py
@@ -315,11 +315,11 @@ class Trading:
             account_id (str): Account identifier to reconcile.
         '''
 
-        runtime = self._execution_manager._accounts.get(account_id)
-        if runtime is None:
+        trading_state = self._execution_manager.get_trading_state(account_id)
+        if trading_state is None:
             return
 
-        for client_order_id, order in list(runtime.trading_state.orders.items()):
+        for client_order_id, order in list(trading_state.orders.items()):
             if order.is_terminal:
                 continue
 
@@ -365,8 +365,8 @@ class Trading:
             order: Local order projection.
         '''
 
-        runtime = self._execution_manager._accounts.get(account_id)
-        if runtime is None:
+        trading_state = self._execution_manager.get_trading_state(account_id)
+        if trading_state is None:
             return
 
         try:
@@ -384,7 +384,7 @@ class Trading:
             return
 
         command_id = order.command_id
-        trade_id = self._execution_manager._command_trade_ids.get(command_id)
+        trade_id = self._execution_manager.trade_id_for_command(command_id)
         if trade_id is None:
             _log.warning(
                 'cannot reconcile fills: no trade_id mapping for command_id=%s order=%s',
@@ -438,8 +438,8 @@ class Trading:
             venue_order: Venue order state.
         '''
 
-        runtime = self._execution_manager._accounts.get(account_id)
-        if runtime is None:
+        trading_state = self._execution_manager.get_trading_state(account_id)
+        if trading_state is None:
             return
 
         ts = datetime.now(timezone.utc)
@@ -494,15 +494,15 @@ class Trading:
             return
 
         report = self._venue_adapter.parse_execution_report(data)
-        runtime = self._execution_manager._accounts.get(account_id)
-        if runtime is None:
+        trading_state = self._execution_manager.get_trading_state(account_id)
+        if trading_state is None:
             _log.warning('execution report for unknown account: %s', account_id)
             return
 
-        order = runtime.trading_state.orders.get(report.client_order_id)
+        order = trading_state.orders.get(report.client_order_id)
         order_is_closed = False
         if order is None:
-            order = runtime.trading_state.closed_orders.get(report.client_order_id)
+            order = trading_state.closed_orders.get(report.client_order_id)
             order_is_closed = order is not None
         if order is None:
             _log.debug(
@@ -552,7 +552,7 @@ class Trading:
             if not report.commission_asset:
                 _log.warning('TRADE report missing commission_asset')
                 return None
-            trade_id = self._execution_manager._command_trade_ids.get(order.command_id)
+            trade_id = self._execution_manager.trade_id_for_command(order.command_id)
             if trade_id is None:
                 _log.warning(
                     'TRADE report has no trade_id mapping for command_id=%s',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 ]
 license = { text = "MIT" }
 requires-python = ">=3.10"
-dependencies = ["structlog>=24.1", "orjson>=3.10", "aiosqlite>=0.20", "aiohttp>=3.10", "numpy>=1.26"]
+dependencies = ["structlog>=24.1", "orjson>=3.10", "aiosqlite>=0.20", "aiohttp>=3.10"]
 
 [project.optional-dependencies]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 ]
 license = { text = "MIT" }
 requires-python = ">=3.10"
-dependencies = ["structlog>=24.1", "orjson>=3.10", "aiosqlite>=0.20", "aiohttp>=3.10"]
+dependencies = ["structlog>=24.1", "orjson>=3.10", "aiosqlite>=0.20", "aiohttp>=3.10", "numpy>=1.26"]
 
 [project.optional-dependencies]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum-praxis"
-version = "0.37.0"
+version = "0.38.0"
 description = "Execution system for Vaquum — Trading sub-system + Account sub-system."
 readme = "README.md"
 authors = [

--- a/tests/test_domain_commands.py
+++ b/tests/test_domain_commands.py
@@ -290,3 +290,24 @@ def test_trade_abort_rejects_empty_string(field: str) -> None:
     kwargs[field] = ''
     with pytest.raises(ValueError, match='non-empty string'):
         TradeAbort(**kwargs)
+
+
+def test_trade_command_single_shot_requires_single_shot_params() -> None:
+
+    with pytest.raises(TypeError, match='SingleShotParams for SINGLE_SHOT'):
+        TradeCommand(
+            command_id='cmd-001',
+            trade_id='trade-001',
+            account_id='acc-1',
+            symbol='BTCUSDT',
+            side=OrderSide.BUY,
+            qty=Decimal('1.0'),
+            order_type=OrderType.LIMIT,
+            execution_mode=ExecutionMode.SINGLE_SHOT,
+            execution_params='not_a_params_object',  # type: ignore[arg-type]
+            timeout=60,
+            reference_price=None,
+            maker_preference=MakerPreference.NO_PREFERENCE,
+            stp_mode=STPMode.NONE,
+            created_at=_TS,
+        )

--- a/tests/test_event_spine.py
+++ b/tests/test_event_spine.py
@@ -4,7 +4,7 @@ Tests for praxis.infrastructure.event_spine.EventSpine.
 
 from __future__ import annotations
 
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from decimal import Decimal
 
@@ -368,3 +368,32 @@ async def test_fill_atomicity_rollback_on_event_insert_failure(
 
     events = await spine.read(epoch_id=_EPOCH)
     assert len(events) == 1
+
+
+@dataclass
+class _Inner:
+    value: Decimal
+    name: str
+
+
+@dataclass
+class _Outer:
+    inner: _Inner
+    timestamp: datetime
+
+
+def test_coerce_nested_dataclass() -> None:
+
+    from praxis.infrastructure.event_spine import _coerce
+
+    raw = {
+        'inner': {'value': '123.45', 'name': 'test'},
+        'timestamp': '2026-01-01T00:00:00+00:00',
+    }
+    result = _coerce(raw, _Outer)
+
+    assert isinstance(result, _Outer)
+    assert isinstance(result.inner, _Inner)
+    assert result.inner.value == Decimal('123.45')
+    assert result.inner.name == 'test'
+    assert result.timestamp == _TS


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

Resolves MMVP-X.2 non-blocker technical debt items identified in the deep audit:

### X.2.1.1 Nested Dataclass Hydration (TD-001)
Adds recursive dataclass detection in `_coerce()` for complex event types containing nested dataclasses. Nested dataclass type hints are cached in `_NESTED_TYPE_HINTS` to avoid repeated reflection overhead.

### X.2.1.2 Execution Params Validation (TD-003)
Validates that `SINGLE_SHOT` mode requires `SingleShotParams` in `TradeCommand.__post_init__`.

### X.2.2.1 Precompute Type Hints (TD-005)
Precomputes `_TYPE_HINTS` dict at module load, avoiding `get_type_hints()` call per hydration. Annotation broadened to `dict[str, dict[str, Any]]` to match `get_type_hints()` return type.

### X.2.2.2 O(1) Abort Order Lookup (TD-008)
Adds `command_to_order` index to `_AccountRuntime`, replacing O(n) iteration with O(1) dict lookup in `_process_abort`.

### X.2.2.3 Single-Pass Event Grouping (TD-012)
Refactors `Trading.start()` event filtering from O(accounts × events) to single-pass `defaultdict` grouping.

### X.2.2.4 Slippage Estimation (TD-015 deferred)
Vectorized optimization was evaluated but reverted due to precision regression: float64 cannot exactly represent all `Decimal` values (e.g. `Decimal('67432.17')`), producing different VWAP and slippage results than exact arithmetic. The original `Decimal` scalar loop is retained with no dependency changes. TD-015 is re-added to `docs/TechnicalDebt.md` with updated guidance noting float64 is not suitable for financial calculations and deferring optimisation until depth exceeds ~100 levels.

### X.2.2.5 orjson for WebSocket (TD-016)
Replaces `json.loads` with `orjson.loads` in WebSocket frame parsing for faster JSON decoding. Input is UTF-8 encoded before passing to `orjson.loads` to ensure compatibility across orjson versions.

### X.2.3.1 Extract Retry Loop (TD-007)
Extracts retry logic from `_signed_request` and `_api_key_request` into shared `_request_with_retry` method using callable factory pattern.

### X.2.3.2 ExecutionManager Accessors (TD-011)
Adds `get_trading_state(account_id)` and `trade_id_for_command(command_id)` public accessors, replacing private attribute access in reconciliation and WS handlers.

### TD-010 Removed (Not Applicable)
Venue LTP benchmark is not needed - Origo supplies LTP as `reference_price` in trade commands.

Bumps version to v0.38.0.

## Checklist

- [x] I have reviewed full diff in "Files changed"
- [x] I left no unnecessary files in the changes
- [x] I ran `python tests/run.py` locally without errors (where applicable)
- [ ] I updated `/docs` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md (unless only docs or other non-code aspect was changed)
- [x] I updated pyproject.toml (unless only docs or other non-code aspect was changed)
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [ ] I linked issue to auto-close on merge (e.g., "Fixes #123") when applicable