### PR TITLE
feat: Health signal exposure (HealthSnapshot, tracker, Trading facade)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -430,3 +430,12 @@
 - Add TD-017 for runtime kline_size registration
 - Add integration tests: launcher lifecycle, command submission, outcome routing, full cycle with strategy_id in [`test_launcher.py`](tests/test_launcher.py)
 - Add 23 tests across new modules (723 total)
+
+## v0.40.0 on 18th of April, 2026
+
+- Add frozen `HealthSnapshot` dataclass with finite/non-negative invariants, ratio bounds, and `consecutive_failures` int check in [`health_snapshot.py`](praxis/core/domain/health_snapshot.py)
+- Add `HealthTracker` with rolling latency + success/failure samples, thread-safe `record_request`, and p99/failure-rate composition in [`health_tracker.py`](praxis/core/health_tracker.py)
+- Wire per-account `HealthTracker` into `BinanceAdapter`: `_request_with_retry` records latency and outcome once per call (retries internal); add `rate_limit_utilization`/`clock_drift_ms` properties; add `sync_clock_drift()` against `/api/v3/time`; add `get_health_snapshot(account_id)` that composes tracker + venue-wide metrics in [`binance_adapter.py`](praxis/infrastructure/binance_adapter.py)
+- Add `get_health_snapshot(account_id) -> HealthSnapshot` to `VenueAdapter` Protocol in [`venue_adapter.py`](praxis/infrastructure/venue_adapter.py)
+- Add `Trading.get_health_snapshot(account_id)` async method (start-required) so Manager can call via `asyncio.run_coroutine_threadsafe(trading.get_health_snapshot(...), trading.loop)` in [`trading.py`](praxis/trading.py)
+- Add 46 tests across `test_health_snapshot.py`, `test_health_tracker.py`, `test_binance_adapter.py` (TestHealthSignals), and `test_trading.py`

--- a/docs/Health.md
+++ b/docs/Health.md
@@ -1,0 +1,52 @@
+# Health
+
+This page explains how Praxis exposes Trading sub-system health to the Manager so the Manager can decide when to throttle, reduce, or halt.
+
+## What The Health Snapshot Is
+
+`praxis/core/domain/health_snapshot.py` defines `HealthSnapshot`: a frozen point-in-time view of one trading account's REST execution health. Every value is bounded so it can drive a deterministic Manager-side policy without further validation.
+
+Fields:
+
+- `latency_p99_ms`: ack latency p99 over the rolling window
+- `consecutive_failures`: count since the last successful REST request
+- `failure_rate`: failing fraction of the rolling window, bounded `[0.0, 1.0]`
+- `rate_limit_headroom`: venue-wide utilisation, bounded `[0.0, 1.0]`, where `0.0` is idle and `1.0` is at limit
+- `clock_drift_ms`: absolute drift from venue server time
+
+Fields default to a healthy zero state when no samples have been collected yet.
+
+## How Metrics Are Collected
+
+`praxis/core/health_tracker.py` (`HealthTracker`) holds the rolling samples per account. The tracker is fed once per logical REST request from `BinanceAdapter._request_with_retry`, with retries treated as one logical attempt rather than per-attempt rows. The tracker is thread-safe; both `record_request` and `snapshot` take the same lock.
+
+Venue-wide measurements live on the adapter, not the tracker:
+
+- `BinanceAdapter.rate_limit_utilization` is derived from existing weight headers
+- `BinanceAdapter.clock_drift_ms` is populated by `sync_clock_drift()` which calls `/api/v3/time`
+
+`BinanceAdapter.get_health_snapshot(account_id)` composes a `HealthSnapshot` from the per-account tracker plus the venue-wide values. Unknown accounts return a default snapshot (zero values) rather than raising.
+
+## How Manager Reads It
+
+The Trading facade exposes the snapshot through `Trading.get_health_snapshot(account_id)`. The method is `async` so a Manager running on its own thread can call it across the asyncio loop boundary without blocking the loop:
+
+```python
+fut = asyncio.run_coroutine_threadsafe(
+    trading.get_health_snapshot(account_id),
+    trading.loop,
+)
+snapshot = fut.result(timeout=...)
+```
+
+The facade requires `Trading.start()` to have been awaited and then delegates straight to the venue adapter.
+
+## Current Scope
+
+The current implementation collects metrics from `BinanceAdapter` REST calls, exposes them through `Trading`, and is consumed by the Manager-side `HealthEvaluator` in Nexus. Push-based delivery (periodic events on the outcome queue) is not implemented; pull is the only contract today.
+
+## Read Next
+
+- [Execution Manager](Execution-Manager.md)
+- [Recovery And Reconciliation](Recovery-And-Reconciliation.md)
+- [Technical Debt](TechnicalDebt.md)

--- a/docs/Health.md
+++ b/docs/Health.md
@@ -16,6 +16,8 @@ Fields:
 
 Fields default to a healthy zero state when no samples have been collected yet.
 
+The field name `rate_limit_headroom` carries utilisation semantics (higher is worse) for parity with the Manager-side `HealthEvaluator` in Nexus, which already exposes the field under that name. The two sides must agree on the symbol, so the apparent mismatch between the noun `headroom` and its actual contents (`used / limit`) is intentional.
+
 ## How Metrics Are Collected
 
 `praxis/core/health_tracker.py` (`HealthTracker`) holds the rolling samples per account. The tracker is fed once per logical REST request from `BinanceAdapter._request_with_retry`, with retries treated as one logical attempt rather than per-attempt rows. The tracker is thread-safe; both `record_request` and `snapshot` take the same lock.

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -27,3 +27,16 @@ Known technical debt in shipped code. Each item includes origin PR, severity, an
 
 **When to fix**: Before depth limits exceed 100 levels.
 **Migration**: If performance becomes an issue, consider Decimal-native cumulative precomputation or early-exit optimizations. Do not use float64 for financial calculations.
+
+---
+
+## TD-018: Clock-drift estimate ignores asymmetric network latency
+
+**Origin**: PR (Health.2 — `feat/TD-health-signals`)
+**Severity**: Low (drift only feeds a 3-threshold health gate)
+**Module**: `praxis/infrastructure/binance_adapter.py`
+
+`sync_clock_drift()` estimates drift as `abs(serverTime - midpoint(local_before, local_after))`. The midpoint assumes symmetric request/response latency. Real-world latency is rarely symmetric, so the reported drift can be off by half the round-trip time.
+
+**When to fix**: Before clock-drift thresholds are tightened past round-trip noise (current `clock_drift_max_ms` default in Nexus is 500 ms, which absorbs typical asymmetry).
+**Migration**: Use a multi-sample method such as Cristian's algorithm with a minimum-RTT round, or rely on system NTP and report the offset reported by the OS instead of probing the venue.

--- a/praxis/core/domain/health_snapshot.py
+++ b/praxis/core/domain/health_snapshot.py
@@ -1,0 +1,74 @@
+'''
+HealthSnapshot dataclass: point-in-time Trading sub-system health metrics.
+
+Exposed to Manager so the Manager-side HealthEvaluator can drive
+operational-mode transitions (ACTIVE / REDUCE_ONLY / HALTED) per
+RFC-4001 §Health.
+'''
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+__all__ = ['HealthSnapshot']
+
+
+@dataclass(frozen=True)
+class HealthSnapshot:
+
+    '''
+    Point-in-time health metrics for one trading account.
+
+    Args:
+        latency_p99_ms (float): Ack latency p99 over the rolling window, in milliseconds.
+        consecutive_failures (int): Number of consecutive request failures since the
+            last success, non-negative.
+        failure_rate (float): Failure rate over the rolling window in the range [0.0, 1.0].
+        rate_limit_headroom (float): Rate limit utilisation fraction in the range [0.0, 1.0].
+            0.0 means idle, 1.0 means at limit. Higher is worse.
+        clock_drift_ms (float): Absolute clock drift from the exchange in milliseconds.
+    '''
+
+    latency_p99_ms: float = 0.0
+    consecutive_failures: int = 0
+    failure_rate: float = 0.0
+    rate_limit_headroom: float = 0.0
+    clock_drift_ms: float = 0.0
+
+    def __post_init__(self) -> None:
+
+        '''Validate invariants at construction time.'''
+
+        for field in (
+            'latency_p99_ms',
+            'failure_rate',
+            'rate_limit_headroom',
+            'clock_drift_ms',
+        ):
+            value = getattr(self, field)
+            if (
+                isinstance(value, bool)
+                or not isinstance(value, (int, float))
+                or not math.isfinite(value)
+                or value < 0
+            ):
+                msg = f'HealthSnapshot.{field} must be a finite non-negative number'
+                raise ValueError(msg)
+
+        for ratio_field in ('failure_rate', 'rate_limit_headroom'):
+            value = getattr(self, ratio_field)
+            if value > 1.0:
+                msg = f'HealthSnapshot.{ratio_field} must be <= 1.0, got {value}'
+                raise ValueError(msg)
+
+        if isinstance(self.consecutive_failures, bool) or not isinstance(
+            self.consecutive_failures,
+            int,
+        ):
+            msg = 'HealthSnapshot.consecutive_failures must be an int'
+            raise ValueError(msg)
+
+        if self.consecutive_failures < 0:
+            msg = 'HealthSnapshot.consecutive_failures must be non-negative'
+            raise ValueError(msg)

--- a/praxis/core/health_tracker.py
+++ b/praxis/core/health_tracker.py
@@ -1,0 +1,149 @@
+'''
+Per-account health-metric collector used by the venue adapter.
+
+HealthTracker keeps rolling samples of REST request latency and success
+status per account. Venue-wide measurements (rate-limit utilisation and
+clock drift) are held outside and supplied when composing a final
+HealthSnapshot.
+'''
+
+from __future__ import annotations
+
+import math
+from collections import deque
+from statistics import quantiles
+from threading import Lock
+
+from praxis.core.domain.health_snapshot import HealthSnapshot
+
+__all__ = ['HealthTracker']
+
+_DEFAULT_WINDOW_SIZE = 256
+_P99_QUANTILES = 100
+
+
+class HealthTracker:
+
+    '''
+    Collect REST request latency and success/failure samples per account.
+
+    Thread-safe for concurrent `record_request` and `snapshot` calls.
+
+    Args:
+        window_size (int): Maximum number of samples retained for rolling
+            latency and failure-rate calculations. Must be positive.
+    '''
+
+    def __init__(self, window_size: int = _DEFAULT_WINDOW_SIZE) -> None:
+
+        if not isinstance(window_size, int) or window_size <= 0:
+            msg = 'HealthTracker.window_size must be a positive int'
+            raise ValueError(msg)
+
+        self._window_size = window_size
+        self._latencies: deque[float] = deque(maxlen=window_size)
+        self._outcomes: deque[bool] = deque(maxlen=window_size)
+        self._consecutive_failures = 0
+        self._lock = Lock()
+
+    def record_request(self, latency_ms: float, succeeded: bool) -> None:
+
+        '''
+        Record the outcome of one REST request.
+
+        Args:
+            latency_ms (float): Request round-trip time in milliseconds.
+                Must be a finite non-negative number.
+            succeeded (bool): True if the request returned a usable response,
+                False if it raised an error after all retries.
+        '''
+
+        if (
+            isinstance(latency_ms, bool)
+            or not isinstance(latency_ms, (int, float))
+            or not math.isfinite(latency_ms)
+            or latency_ms < 0
+        ):
+            msg = 'HealthTracker.record_request: latency_ms must be a finite non-negative number'
+            raise ValueError(msg)
+
+        if not isinstance(succeeded, bool):
+            msg = 'HealthTracker.record_request: succeeded must be a bool'
+            raise ValueError(msg)
+
+        with self._lock:
+            self._latencies.append(float(latency_ms))
+            self._outcomes.append(succeeded)
+            if succeeded:
+                self._consecutive_failures = 0
+            else:
+                self._consecutive_failures += 1
+
+    def reset(self) -> None:
+
+        '''Clear all samples. Used only by tests.'''
+
+        with self._lock:
+            self._latencies.clear()
+            self._outcomes.clear()
+            self._consecutive_failures = 0
+
+    def snapshot(
+        self,
+        rate_limit_utilization: float = 0.0,
+        clock_drift_ms: float = 0.0,
+    ) -> HealthSnapshot:
+
+        '''
+        Build a HealthSnapshot from the current window plus venue-wide inputs.
+
+        Args:
+            rate_limit_utilization (float): Current venue-wide rate-limit
+                utilisation fraction in [0.0, 1.0]. 0.0 means idle, 1.0
+                means at limit.
+            clock_drift_ms (float): Current absolute clock drift from the
+                exchange in milliseconds.
+
+        Returns:
+            HealthSnapshot: Immutable point-in-time metrics.
+        '''
+
+        with self._lock:
+            latencies = list(self._latencies)
+            outcomes = list(self._outcomes)
+            consecutive_failures = self._consecutive_failures
+
+        latency_p99_ms = _percentile_99(latencies)
+        failure_rate = _failure_rate(outcomes)
+
+        return HealthSnapshot(
+            latency_p99_ms=latency_p99_ms,
+            consecutive_failures=consecutive_failures,
+            failure_rate=failure_rate,
+            rate_limit_headroom=rate_limit_utilization,
+            clock_drift_ms=clock_drift_ms,
+        )
+
+
+def _percentile_99(samples: list[float]) -> float:
+
+    '''Return the 99th percentile of samples or 0.0 for an empty list.'''
+
+    if not samples:
+        return 0.0
+
+    if len(samples) == 1:
+        return samples[0]
+
+    return quantiles(samples, n=_P99_QUANTILES, method='inclusive')[-1]
+
+
+def _failure_rate(outcomes: list[bool]) -> float:
+
+    '''Return the fraction of failing outcomes or 0.0 for an empty list.'''
+
+    if not outcomes:
+        return 0.0
+
+    failures = sum(1 for ok in outcomes if not ok)
+    return failures / len(outcomes)

--- a/praxis/core/health_tracker.py
+++ b/praxis/core/health_tracker.py
@@ -79,15 +79,6 @@ class HealthTracker:
             else:
                 self._consecutive_failures += 1
 
-    def reset(self) -> None:
-
-        '''Clear all samples. Used only by tests.'''
-
-        with self._lock:
-            self._latencies.clear()
-            self._outcomes.clear()
-            self._consecutive_failures = 0
-
     def snapshot(
         self,
         rate_limit_utilization: float = 0.0,

--- a/praxis/infrastructure/binance_adapter.py
+++ b/praxis/infrastructure/binance_adapter.py
@@ -15,6 +15,7 @@ import hmac
 import logging
 import math
 import random
+import threading
 import time
 from collections.abc import Callable, Sequence
 from contextlib import AbstractAsyncContextManager
@@ -165,6 +166,7 @@ class BinanceAdapter:
             account_id: HealthTracker() for account_id in self._credentials
         }
         self._clock_drift_ms: float = 0.0
+        self._health_lock = threading.Lock()
 
     @property
     def weight_headroom(self) -> float:
@@ -250,7 +252,8 @@ class BinanceAdapter:
         '''
 
         self._credentials[account_id] = (api_key, api_secret)
-        self._health_trackers.setdefault(account_id, HealthTracker())
+        with self._health_lock:
+            self._health_trackers.setdefault(account_id, HealthTracker())
 
     def unregister_account(self, account_id: str) -> None:
 
@@ -265,7 +268,8 @@ class BinanceAdapter:
         '''
 
         del self._credentials[account_id]
-        self._health_trackers.pop(account_id, None)
+        with self._health_lock:
+            self._health_trackers.pop(account_id, None)
 
     def _get_credentials(self, account_id: str) -> tuple[str, str]:
 
@@ -1404,7 +1408,8 @@ class BinanceAdapter:
 
         '''Record one REST request outcome into the account's HealthTracker.'''
 
-        tracker = self._health_trackers.get(account_id)
+        with self._health_lock:
+            tracker = self._health_trackers.get(account_id)
         if tracker is None:
             return
 
@@ -1464,7 +1469,8 @@ class BinanceAdapter:
             return
 
         local_midpoint_ms = (before_ms + after_ms) / 2
-        self._clock_drift_ms = abs(float(server_time) - local_midpoint_ms)
+        with self._health_lock:
+            self._clock_drift_ms = abs(float(server_time) - local_midpoint_ms)
 
     def get_health_snapshot(self, account_id: str) -> HealthSnapshot:
 
@@ -1482,16 +1488,20 @@ class BinanceAdapter:
             HealthSnapshot: Point-in-time health metrics.
         '''
 
-        tracker = self._health_trackers.get(account_id)
+        with self._health_lock:
+            tracker = self._health_trackers.get(account_id)
+            clock_drift_ms = self._clock_drift_ms
+
+        rate_limit_utilization = self.rate_limit_utilization
         if tracker is None:
             return HealthSnapshot(
-                rate_limit_headroom=self.rate_limit_utilization,
-                clock_drift_ms=self._clock_drift_ms,
+                rate_limit_headroom=rate_limit_utilization,
+                clock_drift_ms=clock_drift_ms,
             )
 
         return tracker.snapshot(
-            rate_limit_utilization=self.rate_limit_utilization,
-            clock_drift_ms=self._clock_drift_ms,
+            rate_limit_utilization=rate_limit_utilization,
+            clock_drift_ms=clock_drift_ms,
         )
 
     def _update_weight_from_headers(

--- a/praxis/infrastructure/binance_adapter.py
+++ b/praxis/infrastructure/binance_adapter.py
@@ -26,6 +26,8 @@ from urllib.parse import urlencode
 import aiohttp
 
 from praxis.core.domain.enums import ExecutionType, OrderSide, OrderStatus, OrderType
+from praxis.core.domain.health_snapshot import HealthSnapshot
+from praxis.core.health_tracker import HealthTracker
 from praxis.infrastructure.binance_urls import (
     MAINNET_REST_URL,
     MAINNET_WS_URL,
@@ -61,6 +63,7 @@ __all__ = [
 
 _API_KEY_HEADER = 'X-MBX-APIKEY'
 _SESSION_TIMEOUT = aiohttp.ClientTimeout(total=30)
+_HTTP_OK = 200
 _HTTP_BAD_REQUEST = 400
 _HTTP_UNAUTHORIZED = 401
 _HTTP_FORBIDDEN = 403
@@ -158,6 +161,10 @@ class BinanceAdapter:
         self._order_count: dict[str, int] = {}
         self._order_count_limit: int = _DEFAULT_ORDER_COUNT_LIMIT
         self._prev_headroom_above_threshold: bool = True
+        self._health_trackers: dict[str, HealthTracker] = {
+            account_id: HealthTracker() for account_id in self._credentials
+        }
+        self._clock_drift_ms: float = 0.0
 
     @property
     def weight_headroom(self) -> float:
@@ -243,6 +250,7 @@ class BinanceAdapter:
         '''
 
         self._credentials[account_id] = (api_key, api_secret)
+        self._health_trackers.setdefault(account_id, HealthTracker())
 
     def unregister_account(self, account_id: str) -> None:
 
@@ -257,6 +265,7 @@ class BinanceAdapter:
         '''
 
         del self._credentials[account_id]
+        self._health_trackers.pop(account_id, None)
 
     def _get_credentials(self, account_id: str) -> tuple[str, str]:
 
@@ -349,6 +358,7 @@ class BinanceAdapter:
         '''
 
         last_error: TransientError | None = None
+        start = time.perf_counter()
 
         for attempt in range(_MAX_RETRIES):
             try:
@@ -356,6 +366,7 @@ class BinanceAdapter:
                     self._update_weight_from_headers(response, account_id)
                     await self._raise_on_error(response)
                     data: Any = await response.json()
+                    self._record_health(account_id, start, succeeded=True)
                     return data
             except TransientError as exc:
                 last_error = exc
@@ -369,6 +380,7 @@ class BinanceAdapter:
                 await asyncio.sleep(delay)
             except RateLimitError as exc:
                 if attempt + 1 == _MAX_RETRIES or exc.status_code != _HTTP_TOO_MANY:
+                    self._record_health(account_id, start, succeeded=False)
                     raise
                 delay = max(0.0, exc.retry_after) if exc.retry_after is not None else random.uniform(0, _RETRY_BASE_DELAY * 2 ** attempt)
                 _log.warning(
@@ -377,6 +389,7 @@ class BinanceAdapter:
                 )
                 await asyncio.sleep(delay)
             except VenueError:
+                self._record_health(account_id, start, succeeded=False)
                 raise
             except (aiohttp.ClientError, TimeoutError, ValueError) as exc:
                 msg = f"Request failed: {exc}"
@@ -391,6 +404,7 @@ class BinanceAdapter:
                 )
                 await asyncio.sleep(delay)
 
+        self._record_health(account_id, start, succeeded=False)
         _log.error(
             'All %d attempts exhausted on %s %s: %s',
             _MAX_RETRIES, method, path, last_error,
@@ -1379,6 +1393,106 @@ class BinanceAdapter:
         except (KeyError, TypeError, ArithmeticError, ValueError) as exc:
             msg = f"Malformed depth payload for {symbol!r}: {exc}"
             raise VenueError(msg) from exc
+
+    def _record_health(
+        self,
+        account_id: str,
+        start: float,
+        *,
+        succeeded: bool,
+    ) -> None:
+
+        '''Record one REST request outcome into the account's HealthTracker.'''
+
+        tracker = self._health_trackers.get(account_id)
+        if tracker is None:
+            return
+
+        latency_ms = max(0.0, (time.perf_counter() - start) * 1000.0)
+        tracker.record_request(latency_ms=latency_ms, succeeded=succeeded)
+
+    @property
+    def rate_limit_utilization(self) -> float:
+
+        '''
+        Current venue-wide rate-limit utilisation fraction.
+
+        Returns:
+            float: Value in [0.0, 1.0]. 0.0 means idle, 1.0 means at limit.
+        '''
+
+        if self._weight_limit <= 0:
+            return 0.0
+
+        return min(1.0, max(0.0, self._used_weight / self._weight_limit))
+
+    @property
+    def clock_drift_ms(self) -> float:
+
+        '''
+        Last measured absolute clock drift from the exchange in milliseconds.
+
+        Returns 0.0 until sync_clock_drift has been called successfully.
+        '''
+
+        return self._clock_drift_ms
+
+    async def sync_clock_drift(self) -> None:
+
+        '''
+        Measure and store absolute clock drift against Binance server time.
+
+        Calls the public `/api/v3/time` endpoint. Silently skips on venue
+        or transport errors so health collection remains best-effort.
+        '''
+
+        session = await self._ensure_session()
+        url = f'{self._base_url}/api/v3/time'
+
+        try:
+            before_ms = time.time() * 1000.0
+            async with session.get(url) as response:
+                after_ms = time.time() * 1000.0
+                if response.status != _HTTP_OK:
+                    return
+                payload = await response.json()
+        except (aiohttp.ClientError, TimeoutError, ValueError):
+            return
+
+        server_time = payload.get('serverTime')
+        if not isinstance(server_time, (int, float)):
+            return
+
+        local_midpoint_ms = (before_ms + after_ms) / 2
+        self._clock_drift_ms = abs(float(server_time) - local_midpoint_ms)
+
+    def get_health_snapshot(self, account_id: str) -> HealthSnapshot:
+
+        '''
+        Compose a HealthSnapshot for a registered account.
+
+        Returns default (empty) snapshot when the account has no tracker
+        yet; the venue-wide rate-limit utilisation and clock drift are
+        always included.
+
+        Args:
+            account_id (str): Account identifier.
+
+        Returns:
+            HealthSnapshot: Point-in-time health metrics.
+        '''
+
+        tracker = self._health_trackers.get(account_id)
+        if tracker is None:
+            return HealthSnapshot(
+                rate_limit_headroom=self.rate_limit_utilization,
+                clock_drift_ms=self._clock_drift_ms,
+            )
+
+        return tracker.snapshot(
+            rate_limit_utilization=self.rate_limit_utilization,
+            clock_drift_ms=self._clock_drift_ms,
+        )
 
     def _update_weight_from_headers(
         self,

--- a/praxis/infrastructure/binance_adapter.py
+++ b/praxis/infrastructure/binance_adapter.py
@@ -1440,7 +1440,8 @@ class BinanceAdapter:
         Returns 0.0 until sync_clock_drift has been called successfully.
         '''
 
-        return self._clock_drift_ms
+        with self._health_lock:
+            return self._clock_drift_ms
 
     async def sync_clock_drift(self) -> None:
 

--- a/praxis/infrastructure/venue_adapter.py
+++ b/praxis/infrastructure/venue_adapter.py
@@ -15,6 +15,7 @@ from decimal import Decimal
 from typing import Any, Protocol, runtime_checkable
 
 from praxis.core.domain.enums import ExecutionType, OrderSide, OrderStatus, OrderType
+from praxis.core.domain.health_snapshot import HealthSnapshot
 
 
 __all__ = [
@@ -629,6 +630,21 @@ class VenueAdapter(Protocol):
 
         Returns:
             int: Server time in milliseconds since epoch
+        '''
+
+        ...
+
+    def get_health_snapshot(self, account_id: str) -> HealthSnapshot:
+        '''
+        Return a point-in-time HealthSnapshot for an account.
+
+        Args:
+            account_id (str): Account identifier.
+
+        Returns:
+            HealthSnapshot: Latest known health metrics. Implementations
+                must return defaults (zero) rather than raise when no
+                samples have been collected yet.
         '''
 
         ...

--- a/praxis/trading.py
+++ b/praxis/trading.py
@@ -758,6 +758,12 @@ class Trading:
         asyncio.run_coroutine_threadsafe(trading.get_health_snapshot(...),
         trading.loop) without blocking the loop.
 
+        Unlike submit_command and submit_abort, this does not require the
+        account to be ready: health is intentionally pollable across the
+        whole lifecycle (the underlying adapter returns a default zeroed
+        snapshot for unknown accounts) so a Manager can observe degradation
+        before the account is fully wired.
+
         Args:
             account_id: Account whose snapshot is requested.
 

--- a/praxis/trading.py
+++ b/praxis/trading.py
@@ -19,6 +19,7 @@ from praxis.core.domain.enums import (
     OrderType,
     STPMode,
 )
+from praxis.core.domain.health_snapshot import HealthSnapshot
 from praxis.core.domain.position import Position
 from praxis.core.domain.single_shot_params import SingleShotParams
 from praxis.core.domain.trade_abort import TradeAbort
@@ -747,6 +748,27 @@ class Trading:
             raise RuntimeError(msg)
         self._require_account_ready(abort.account_id)
         self._inbound.submit_abort(abort)
+
+    async def get_health_snapshot(self, account_id: str) -> HealthSnapshot:
+        '''Return a HealthSnapshot for an account.
+
+        Awaitable so Manager (running on a separate thread) can call via
+        asyncio.run_coroutine_threadsafe(trading.get_health_snapshot(...),
+        trading.loop).
+
+        Args:
+            account_id: Account whose snapshot is requested.
+
+        Returns:
+            HealthSnapshot: Latest known metrics. Returns default (zero)
+                values when no samples have been recorded yet.
+
+        Raises:
+            RuntimeError: If Trading.start() has not been awaited.
+        '''
+
+        self._require_started()
+        return self._venue_adapter.get_health_snapshot(account_id)
 
     def pull_positions(self, account_id: str) -> dict[tuple[str, str], Position]:
         '''Pull detached positions snapshot through inbound facade.'''

--- a/praxis/trading.py
+++ b/praxis/trading.py
@@ -752,9 +752,11 @@ class Trading:
     async def get_health_snapshot(self, account_id: str) -> HealthSnapshot:
         '''Return a HealthSnapshot for an account.
 
-        Awaitable so Manager (running on a separate thread) can call via
+        Body is synchronous (snapshot composition is in-memory). The method
+        is declared `async` so a Manager thread can dispatch the call
+        across the asyncio loop boundary via
         asyncio.run_coroutine_threadsafe(trading.get_health_snapshot(...),
-        trading.loop).
+        trading.loop) without blocking the loop.
 
         Args:
             account_id: Account whose snapshot is requested.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum-praxis"
-version = "0.39.0"
+version = "0.40.0"
 description = "Execution system for Vaquum — Trading sub-system + Account sub-system."
 readme = "README.md"
 authors = [

--- a/tests/test_binance_adapter.py
+++ b/tests/test_binance_adapter.py
@@ -5,6 +5,7 @@ Tests for praxis.infrastructure.binance_adapter.
 from __future__ import annotations
 
 import logging
+import time
 from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Any, ClassVar
@@ -2717,3 +2718,77 @@ class TestHealthSignals:
 
         assert snapshot.rate_limit_headroom == pytest.approx(0.6)
         assert snapshot.clock_drift_ms == 8.0
+
+    def test_health_trackers_are_isolated_per_account(self) -> None:
+
+        adapter = BinanceAdapter(_BASE_URL, _WS_BASE_URL)
+        adapter.register_account('acc-a', 'k', 's')
+        adapter.register_account('acc-b', 'k', 's')
+
+        adapter._health_trackers['acc-a'].record_request(latency_ms=5.0, succeeded=False)
+        adapter._health_trackers['acc-a'].record_request(latency_ms=5.0, succeeded=False)
+
+        snap_a = adapter.get_health_snapshot('acc-a')
+        snap_b = adapter.get_health_snapshot('acc-b')
+
+        assert snap_a.consecutive_failures == 2
+        assert snap_a.failure_rate == 1.0
+        assert snap_b.consecutive_failures == 0
+        assert snap_b.failure_rate == 0.0
+
+    @pytest.mark.asyncio
+    async def test_sync_clock_drift_populates_drift_ms(self) -> None:
+
+        adapter = BinanceAdapter(_BASE_URL, _WS_BASE_URL)
+        target_drift_ms = 12345.0
+
+        response = AsyncMock()
+        response.status = 200
+        response.json = AsyncMock(
+            return_value={'serverTime': time.time() * 1000.0 + target_drift_ms},
+        )
+        ctx = MagicMock()
+        ctx.__aenter__ = AsyncMock(return_value=response)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        session = MagicMock()
+        session.get = MagicMock(return_value=ctx)
+        session.closed = False
+        adapter._session = session
+
+        await adapter.sync_clock_drift()
+
+        assert adapter.clock_drift_ms == pytest.approx(target_drift_ms, rel=0.05)
+
+    @pytest.mark.asyncio
+    async def test_sync_clock_drift_silent_on_non_ok_status(self) -> None:
+
+        adapter = BinanceAdapter(_BASE_URL, _WS_BASE_URL)
+
+        response = AsyncMock()
+        response.status = 503
+        response.json = AsyncMock(return_value={})
+        ctx = MagicMock()
+        ctx.__aenter__ = AsyncMock(return_value=response)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        session = MagicMock()
+        session.get = MagicMock(return_value=ctx)
+        session.closed = False
+        adapter._session = session
+
+        await adapter.sync_clock_drift()
+
+        assert adapter.clock_drift_ms == 0.0
+
+    @pytest.mark.asyncio
+    async def test_sync_clock_drift_silent_on_transport_error(self) -> None:
+
+        adapter = BinanceAdapter(_BASE_URL, _WS_BASE_URL)
+
+        session = MagicMock()
+        session.get = MagicMock(side_effect=aiohttp.ClientError('boom'))
+        session.closed = False
+        adapter._session = session
+
+        await adapter.sync_clock_drift()
+
+        assert adapter.clock_drift_ms == 0.0

--- a/tests/test_binance_adapter.py
+++ b/tests/test_binance_adapter.py
@@ -2637,3 +2637,83 @@ class TestCancelOrderList:
         adapter = _make_adapter()
         with pytest.raises(ValueError, match='At least one of'):
             await adapter.cancel_order_list(_ACCOUNT_ID, 'BTCUSDT')
+
+
+class TestHealthSignals:
+
+    def test_register_account_creates_health_tracker(self) -> None:
+
+        adapter = BinanceAdapter(_BASE_URL, _WS_BASE_URL)
+        adapter.register_account('acc1', 'k', 's')
+
+        assert 'acc1' in adapter._health_trackers
+
+    def test_unregister_account_removes_health_tracker(self) -> None:
+
+        adapter = _make_adapter()
+        adapter.unregister_account(_ACCOUNT_ID)
+
+        assert _ACCOUNT_ID not in adapter._health_trackers
+
+    def test_get_health_snapshot_defaults_when_unknown(self) -> None:
+
+        adapter = BinanceAdapter(_BASE_URL, _WS_BASE_URL)
+        snapshot = adapter.get_health_snapshot('unknown')
+
+        assert snapshot.latency_p99_ms == 0.0
+        assert snapshot.consecutive_failures == 0
+
+    def test_rate_limit_utilization_reflects_used_weight(self) -> None:
+
+        adapter = BinanceAdapter(_BASE_URL, _WS_BASE_URL)
+        adapter._used_weight = 300
+        adapter._weight_limit = 1000
+
+        assert adapter.rate_limit_utilization == pytest.approx(0.3)
+
+    def test_rate_limit_utilization_clamps_above_one(self) -> None:
+
+        adapter = BinanceAdapter(_BASE_URL, _WS_BASE_URL)
+        adapter._used_weight = 2000
+        adapter._weight_limit = 1000
+
+        assert adapter.rate_limit_utilization == 1.0
+
+    @pytest.mark.asyncio
+    async def test_successful_signed_request_records_success(self) -> None:
+
+        adapter = _make_adapter()
+        _patch_session(adapter, _mock_response(200, {'ok': True}))
+
+        await adapter._signed_request('GET', '/api/v3/account', {}, _ACCOUNT_ID)
+
+        snapshot = adapter.get_health_snapshot(_ACCOUNT_ID)
+        assert snapshot.consecutive_failures == 0
+        assert snapshot.failure_rate == 0.0
+
+    @pytest.mark.asyncio
+    async def test_non_retryable_rate_limit_records_failure(self) -> None:
+
+        adapter = _make_adapter()
+        _patch_session(adapter, _mock_response(403, {'code': -1, 'msg': 'banned'}))
+
+        with pytest.raises(RateLimitError):
+            await adapter._signed_request('GET', '/api/v3/account', {}, _ACCOUNT_ID)
+
+        snapshot = adapter.get_health_snapshot(_ACCOUNT_ID)
+        assert snapshot.consecutive_failures == 1
+        assert snapshot.failure_rate == 1.0
+
+    def test_health_snapshot_composes_venue_metrics(self) -> None:
+
+        adapter = _make_adapter()
+        tracker = adapter._health_trackers[_ACCOUNT_ID]
+        tracker.record_request(latency_ms=12.0, succeeded=True)
+        adapter._used_weight = 600
+        adapter._weight_limit = 1000
+        adapter._clock_drift_ms = 8.0
+
+        snapshot = adapter.get_health_snapshot(_ACCOUNT_ID)
+
+        assert snapshot.rate_limit_headroom == pytest.approx(0.6)
+        assert snapshot.clock_drift_ms == 8.0

--- a/tests/test_health_snapshot.py
+++ b/tests/test_health_snapshot.py
@@ -1,0 +1,136 @@
+'''
+Tests for HealthSnapshot dataclass invariants.
+'''
+
+from __future__ import annotations
+
+import math
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from praxis.core.domain.health_snapshot import HealthSnapshot
+
+
+def test_defaults_represent_healthy_state() -> None:
+
+    snapshot = HealthSnapshot()
+
+    assert snapshot.latency_p99_ms == 0.0
+    assert snapshot.consecutive_failures == 0
+    assert snapshot.failure_rate == 0.0
+    assert snapshot.rate_limit_headroom == 0.0
+    assert snapshot.clock_drift_ms == 0.0
+
+
+def test_custom_values_construct() -> None:
+
+    snapshot = HealthSnapshot(
+        latency_p99_ms=120.5,
+        consecutive_failures=2,
+        failure_rate=0.1,
+        rate_limit_headroom=0.75,
+        clock_drift_ms=5.0,
+    )
+
+    assert snapshot.latency_p99_ms == 120.5
+    assert snapshot.consecutive_failures == 2
+    assert snapshot.failure_rate == 0.1
+    assert snapshot.rate_limit_headroom == 0.75
+    assert snapshot.clock_drift_ms == 5.0
+
+
+@pytest.mark.parametrize(
+    'field',
+    [
+        'latency_p99_ms',
+        'failure_rate',
+        'rate_limit_headroom',
+        'clock_drift_ms',
+    ],
+)
+def test_negative_values_rejected(field: str) -> None:
+
+    kwargs = {field: -0.1}
+    with pytest.raises(ValueError, match=f'{field} must be a finite non-negative number'):
+        HealthSnapshot(**kwargs)
+
+
+@pytest.mark.parametrize(
+    'field',
+    [
+        'latency_p99_ms',
+        'failure_rate',
+        'rate_limit_headroom',
+        'clock_drift_ms',
+    ],
+)
+def test_nan_values_rejected(field: str) -> None:
+
+    kwargs = {field: math.nan}
+    with pytest.raises(ValueError, match=f'{field} must be a finite non-negative number'):
+        HealthSnapshot(**kwargs)
+
+
+@pytest.mark.parametrize(
+    'field',
+    [
+        'latency_p99_ms',
+        'failure_rate',
+        'rate_limit_headroom',
+        'clock_drift_ms',
+    ],
+)
+def test_bool_values_rejected(field: str) -> None:
+
+    kwargs = {field: True}
+    with pytest.raises(ValueError, match=f'{field} must be a finite non-negative number'):
+        HealthSnapshot(**kwargs)
+
+
+@pytest.mark.parametrize(
+    'field',
+    [
+        'failure_rate',
+        'rate_limit_headroom',
+    ],
+)
+def test_ratio_above_one_rejected(field: str) -> None:
+
+    kwargs = {field: 1.01}
+    with pytest.raises(ValueError, match=f'{field} must be <= 1.0'):
+        HealthSnapshot(**kwargs)
+
+
+def test_consecutive_failures_must_be_int() -> None:
+
+    with pytest.raises(ValueError, match='consecutive_failures must be an int'):
+        HealthSnapshot(consecutive_failures=1.5)  # type: ignore[arg-type]
+
+
+def test_consecutive_failures_bool_rejected() -> None:
+
+    with pytest.raises(ValueError, match='consecutive_failures must be an int'):
+        HealthSnapshot(consecutive_failures=True)  # type: ignore[arg-type]
+
+
+def test_consecutive_failures_negative_rejected() -> None:
+
+    with pytest.raises(ValueError, match='consecutive_failures must be non-negative'):
+        HealthSnapshot(consecutive_failures=-1)
+
+
+def test_ratio_one_accepted() -> None:
+
+    snapshot = HealthSnapshot(failure_rate=1.0, rate_limit_headroom=1.0)
+
+    assert snapshot.failure_rate == 1.0
+    assert snapshot.rate_limit_headroom == 1.0
+
+
+def test_frozen_assignment_rejected() -> None:
+
+    snapshot = HealthSnapshot()
+
+    with pytest.raises(FrozenInstanceError):
+        snapshot.latency_p99_ms = 1.0  # type: ignore[misc]

--- a/tests/test_health_tracker.py
+++ b/tests/test_health_tracker.py
@@ -84,20 +84,6 @@ def test_window_size_truncates_old_samples() -> None:
     assert snapshot.latency_p99_ms > 300.0
 
 
-def test_reset_clears_state() -> None:
-
-    tracker = HealthTracker()
-    tracker.record_request(latency_ms=5.0, succeeded=False)
-    tracker.record_request(latency_ms=5.0, succeeded=False)
-
-    tracker.reset()
-
-    snapshot = tracker.snapshot()
-    assert snapshot.consecutive_failures == 0
-    assert snapshot.failure_rate == 0.0
-    assert snapshot.latency_p99_ms == 0.0
-
-
 def test_negative_latency_rejected() -> None:
 
     tracker = HealthTracker()

--- a/tests/test_health_tracker.py
+++ b/tests/test_health_tracker.py
@@ -1,0 +1,122 @@
+'''
+Tests for HealthTracker: rolling latency/failure collector.
+'''
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from praxis.core.health_tracker import HealthTracker
+
+
+def test_invalid_window_size_rejected() -> None:
+
+    with pytest.raises(ValueError, match='window_size must be a positive int'):
+        HealthTracker(window_size=0)
+
+
+def test_record_request_updates_counters() -> None:
+
+    tracker = HealthTracker()
+
+    tracker.record_request(latency_ms=10.0, succeeded=True)
+    tracker.record_request(latency_ms=20.0, succeeded=False)
+    tracker.record_request(latency_ms=30.0, succeeded=False)
+
+    snapshot = tracker.snapshot()
+    assert snapshot.consecutive_failures == 2
+    assert snapshot.failure_rate == pytest.approx(2 / 3)
+
+
+def test_consecutive_failures_reset_on_success() -> None:
+
+    tracker = HealthTracker()
+    for _ in range(3):
+        tracker.record_request(latency_ms=5.0, succeeded=False)
+    tracker.record_request(latency_ms=5.0, succeeded=True)
+
+    snapshot = tracker.snapshot()
+    assert snapshot.consecutive_failures == 0
+
+
+def test_p99_computed_from_samples() -> None:
+
+    tracker = HealthTracker()
+    for value in range(100):
+        tracker.record_request(latency_ms=float(value), succeeded=True)
+
+    snapshot = tracker.snapshot()
+    assert snapshot.latency_p99_ms == pytest.approx(99.0, abs=1.5)
+
+
+def test_empty_snapshot_returns_defaults() -> None:
+
+    tracker = HealthTracker()
+
+    snapshot = tracker.snapshot()
+    assert snapshot.latency_p99_ms == 0.0
+    assert snapshot.consecutive_failures == 0
+    assert snapshot.failure_rate == 0.0
+    assert snapshot.rate_limit_headroom == 0.0
+    assert snapshot.clock_drift_ms == 0.0
+
+
+def test_snapshot_passes_through_venue_metrics() -> None:
+
+    tracker = HealthTracker()
+    tracker.record_request(latency_ms=1.0, succeeded=True)
+
+    snapshot = tracker.snapshot(rate_limit_utilization=0.7, clock_drift_ms=25.0)
+    assert snapshot.rate_limit_headroom == 0.7
+    assert snapshot.clock_drift_ms == 25.0
+
+
+def test_window_size_truncates_old_samples() -> None:
+
+    tracker = HealthTracker(window_size=3)
+    for value in (100.0, 200.0, 300.0, 400.0):
+        tracker.record_request(latency_ms=value, succeeded=True)
+
+    snapshot = tracker.snapshot()
+    assert snapshot.latency_p99_ms == pytest.approx(400.0, abs=5.0)
+    assert snapshot.latency_p99_ms > 300.0
+
+
+def test_reset_clears_state() -> None:
+
+    tracker = HealthTracker()
+    tracker.record_request(latency_ms=5.0, succeeded=False)
+    tracker.record_request(latency_ms=5.0, succeeded=False)
+
+    tracker.reset()
+
+    snapshot = tracker.snapshot()
+    assert snapshot.consecutive_failures == 0
+    assert snapshot.failure_rate == 0.0
+    assert snapshot.latency_p99_ms == 0.0
+
+
+def test_negative_latency_rejected() -> None:
+
+    tracker = HealthTracker()
+
+    with pytest.raises(ValueError, match='latency_ms must be a finite non-negative number'):
+        tracker.record_request(latency_ms=-1.0, succeeded=True)
+
+
+def test_nan_latency_rejected() -> None:
+
+    tracker = HealthTracker()
+
+    with pytest.raises(ValueError, match='latency_ms must be a finite non-negative number'):
+        tracker.record_request(latency_ms=math.nan, succeeded=True)
+
+
+def test_non_bool_succeeded_rejected() -> None:
+
+    tracker = HealthTracker()
+
+    with pytest.raises(ValueError, match='succeeded must be a bool'):
+        tracker.record_request(latency_ms=1.0, succeeded=1)  # type: ignore[arg-type]

--- a/tests/test_trading.py
+++ b/tests/test_trading.py
@@ -19,6 +19,7 @@ from praxis.core.domain.enums import (
     STPMode,
     TradeStatus,
 )
+from praxis.core.domain.health_snapshot import HealthSnapshot
 from praxis.core.domain.position import Position
 from praxis.core.domain.order import Order
 from praxis.core.domain.single_shot_params import SingleShotParams
@@ -171,6 +172,10 @@ class _InjectedVenueAdapter:
         del data
         raise NotImplementedError
 
+    def get_health_snapshot(self, account_id: str) -> HealthSnapshot:
+        del account_id
+        return HealthSnapshot()
+
 
 class _FakeInbound:
     def __init__(self) -> None:
@@ -273,6 +278,39 @@ async def test_trading_delegates_facade_methods(spine: EventSpine) -> None:
     assert any(name == 'submit_abort' for name, _ in fake_inbound.calls)
     assert any(name == 'pull_positions' for name, _ in fake_inbound.calls)
     assert positions[('trade-1', 'acc-1')].qty == Decimal('1')
+
+
+@pytest.mark.asyncio
+async def test_trading_get_health_snapshot_delegates_to_adapter(
+    spine: EventSpine,
+) -> None:
+    adapter = _InjectedVenueAdapter()
+    trading = Trading(
+        config=TradingConfig(epoch_id=1),
+        event_spine=spine,
+        venue_adapter=cast(VenueAdapter, adapter),
+    )
+    await trading.start()
+
+    snapshot = await trading.get_health_snapshot('acc-1')
+
+    assert isinstance(snapshot, HealthSnapshot)
+    assert snapshot.consecutive_failures == 0
+
+
+@pytest.mark.asyncio
+async def test_trading_get_health_snapshot_requires_started(
+    spine: EventSpine,
+) -> None:
+    adapter = _InjectedVenueAdapter()
+    trading = Trading(
+        config=TradingConfig(epoch_id=1),
+        event_spine=spine,
+        venue_adapter=cast(VenueAdapter, adapter),
+    )
+
+    with pytest.raises(RuntimeError, match=r'Trading\.start'):
+        await trading.get_health_snapshot('acc-1')
 
 
 @pytest.mark.asyncio

--- a/tests/test_venue_adapter.py
+++ b/tests/test_venue_adapter.py
@@ -321,6 +321,8 @@ class TestVenueAdapterProtocol:
 
             def parse_execution_report(self, *_args: Any, **_kwargs: Any) -> None: ...
 
+            def get_health_snapshot(self, *_args: Any, **_kwargs: Any) -> None: ...
+
         assert isinstance(_FakeAdapter(), VenueAdapter)
 
     def test_non_conforming_class_not_isinstance(self) -> None:


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

Implements MMVP-TD issue [#68](https://github.com/Vaquum/Praxis/issues/68) Health subitems (Health.1–Health.4) — the Trading sub-system's contribution to RFC-4001 §Health. After this PR, Manager (Nexus) can pull a `HealthSnapshot` per account so its `HealthEvaluator` can drive `ACTIVE` / `REDUCE_ONLY` / `HALTED` mode transitions.

**New files:**
- [`praxis/core/domain/health_snapshot.py`](praxis/core/domain/health_snapshot.py) — frozen `HealthSnapshot` dataclass with finite/non-negative invariants, `[0, 1]` ratio bounds for `failure_rate` / `rate_limit_headroom`, and int-only `consecutive_failures`
- [`praxis/core/health_tracker.py`](praxis/core/health_tracker.py) — `HealthTracker` rolling-window collector; thread-safe `record_request(latency_ms, succeeded)`; on-demand p99 / failure-rate / `consecutive_failures` composition
- [`docs/Health.md`](docs/Health.md) — page describing the snapshot contract, collection path, and cross-thread call pattern
- [`tests/test_health_snapshot.py`](tests/test_health_snapshot.py) — 21 contract tests
- [`tests/test_health_tracker.py`](tests/test_health_tracker.py) — 10 tracker tests

**Modified files:**
- [`praxis/infrastructure/binance_adapter.py`](praxis/infrastructure/binance_adapter.py) — owns one `HealthTracker` per registered account; `_request_with_retry` records latency + outcome once per logical request (retries internal, not double-counted); new `rate_limit_utilization` and `clock_drift_ms` properties; `sync_clock_drift()` populates drift from `/api/v3/time`; `get_health_snapshot(account_id)` composes a snapshot. `_health_lock` guards registry mutation, lookup, snapshot composition, and `_clock_drift_ms` assignment.
- [`praxis/infrastructure/venue_adapter.py`](praxis/infrastructure/venue_adapter.py) — `get_health_snapshot(account_id) -> HealthSnapshot` added to the `VenueAdapter` Protocol so the Trading facade can delegate without depending on the concrete adapter.
- [`praxis/trading.py`](praxis/trading.py) — `Trading.get_health_snapshot(account_id)` async method (start-required, intentionally not `account_ready`-required) so Manager can call via `asyncio.run_coroutine_threadsafe(trading.get_health_snapshot(...), trading.loop)` from its own thread.
- [`tests/test_binance_adapter.py`](tests/test_binance_adapter.py) — `TestHealthSignals` class with 12 tests covering REST recording, rate-limit utilisation, snapshot composition, per-account isolation, and `sync_clock_drift` happy/non-OK/transport-error branches.
- [`tests/test_trading.py`](tests/test_trading.py) — 2 tests for facade delegation and start-required behaviour.
- [`tests/test_venue_adapter.py`](tests/test_venue_adapter.py) — Protocol conformance test extended.
- [`docs/TechnicalDebt.md`](docs/TechnicalDebt.md) — adds TD-018 noting that `sync_clock_drift`'s midpoint estimator ignores asymmetric network latency.
- `CHANGELOG.md` — v0.40.0 entry
- `pyproject.toml` — version bump 0.39.0 → 0.40.0

**Design decisions:**
- **Pull, not push.** Manager polls; outcome-queue health events are out of scope for now (issue #68 leaves it as either/or; pull is the simpler contract).
- **`async def Trading.get_health_snapshot` with sync body.** The signature exists so a sync Manager thread can dispatch via `run_coroutine_threadsafe` without blocking the loop — composition itself is in-memory.
- **`rate_limit_headroom` carries utilisation semantics** (higher is worse). Field name preserved for parity with the Manager-side `HealthSnapshot` in Nexus; intentional, documented in `docs/Health.md`.
- **Per-account `HealthTracker`** for latency + failures (account-scoped); venue-wide for `rate_limit_utilization` and `clock_drift_ms` (one venue per adapter).
- **`_health_lock`** added pre-emptively against the same race pattern Copilot flagged on `_outcome_queues` in PR #69 (Launcher mutates registry from a non-loop thread; loop reads on the hot path).
- **Retries don't double-count.** `_request_with_retry` records latency from the entry timestamp through to the resolved outcome — one logical row per call.

## Checklist

- [x] I have reviewed full diff in "Files changed"
- [x] I left no unnecessary files in the changes
- [x] I ran `python tests/run.py` locally without errors (where applicable)
- [x] I updated `/docs` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md (unless only docs or other non-code aspect was changed)
- [x] I updated pyproject.toml (unless only docs or other non-code aspect was changed)
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [ ] I linked issue to auto-close on merge (e.g., "Fixes #123") when applicable

Refs #68 (Health.1–Health.4)

