### PR TITLE
docs: round-17 TechnicalDebt addition (TD-036)

### DIFF
--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -248,3 +248,17 @@ When `order.filled_qty > cmd.qty` (duplicate WS fill, venue rounding past target
 
 **When to fix**: When venue overfill behavior becomes operationally observable, OR when strategies need a consistent mid-run view of venue truth.
 **Migration**: Raise an explicit reconcile event (or persist the clamp on the spine) so mid-run state is not silently undersized, OR honor venue truth and let Nexus aggregates absorb the surplus via a `_grow_position` extension.
+
+
+---
+
+## TD-036: Round-14 MAJOR-P regression test asserts only one race direction
+
+**Origin**: Round-17 Codex-supervised audit (R15 TD-007 carried forward as FINAL-TD-15)
+**Severity**: Low (test asymmetry; remediation test for Nexus FINAL-MAJOR-01 supersedes this)
+**Module**: `tests/test_launcher_command_registry_lock.py:303-381`
+
+`test_strategy_id_resolvable_during_send_order_concurrent` asserts that whenever the reader sees an entry in `command_contexts`, it ALSO sees an entry in `command_strategy_ids` — the post-MAJOR-P invariant that strategy_ids is set FIRST. The dangerous direction (reader sees `strategy_ids[cid]` populated but `contexts.get(cid)` returns None — the actual FINAL-MAJOR-01 race window) is NOT asserted; the test passes vacuously against the remaining race window.
+
+**When to fix**: When FINAL-MAJOR-01 is fixed (cross-repo: register Praxis-side launcher PR holding `command_registry_lock` across the entire critical section). Test priority is HIGH at that point — this test is the regression guard for FINAL-MAJOR-01.
+**Migration**: Add the symmetric `'observed strategy_ids[cid] populated but contexts missing for {cid}'` assertion in the reader; drive a synthetic outcome during the work between strategy_ids write and contexts write; assert the outcome is processed (not dropped).


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

Appends one deferred-finding entry (TD-036) to \`docs/TechnicalDebt.md\` from the round-17 Codex-supervised audit (R17-E final dedup ledger, FINAL-TD-15).

Companion issue tracking the round-17 MAJORs: #83.

TD-036 documents the asymmetric-direction-only assertion in the round-14 MAJOR-P regression test (\`tests/test_launcher_command_registry_lock.py:303-381\`); the symmetric assertion is needed to catch the actual race window that the cross-repo FINAL-MAJOR-01 fix targets. Lift the test priority when FINAL-MAJOR-01 lands.

## Checklist

- [x] I have reviewed full diff in \"Files changed\"
- [x] I left no unnecessary files in the changes
- [x] I ran \`python tests/run.py\` locally without errors (where applicable)
- [x] I updated \`/docs\` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md
- [x] I updated pyproject.toml
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [x] I linked issue to auto-close on merge (e.g., \"Fixes #123\") when applicable