### PR TITLE
feat: GHCR image-build CI workflow + Nexus 0.39.0 pin (v0.50.0)

### DIFF
--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -12,6 +12,7 @@ concurrency:
 permissions:
   contents: read
   packages: write
+  actions: write
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -40,7 +40,7 @@ jobs:
         id: version
         run: |
           set -euo pipefail
-          version=$(grep -E '^version = "' pyproject.toml | head -1 | sed -E 's/version = "(.+)"/\1/')
+          version=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
           test -n "$version" || { echo "::error::could not parse version from pyproject.toml"; exit 1; }
           echo "value=${version}" >> "$GITHUB_OUTPUT"
           echo "resolved version: ${version}"

--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: build-image-praxis
+  group: build-image-praxis-${{ github.ref }}
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -35,6 +35,15 @@ jobs:
           echo "image=${image_lc}" >> "$GITHUB_OUTPUT"
           echo "resolved image: ${image_lc}"
 
+      - name: Read version from pyproject.toml
+        id: version
+        run: |
+          set -euo pipefail
+          version=$(grep -E '^version = "' pyproject.toml | head -1 | sed -E 's/version = "(.+)"/\1/')
+          test -n "$version" || { echo "::error::could not parse version from pyproject.toml"; exit 1; }
+          echo "value=${version}" >> "$GITHUB_OUTPUT"
+          echo "resolved version: ${version}"
+
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
@@ -50,8 +59,9 @@ jobs:
         with:
           context: .
           push: true
-          build-args: |
-            GIT_SHA=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           tags: |
             ${{ steps.meta.outputs.image }}:sha-${{ github.sha }}
-            ${{ steps.meta.outputs.image }}:main
+            ${{ github.ref == 'refs/heads/main' && format('{0}:{1}', steps.meta.outputs.image, steps.version.outputs.value) || '' }}
+            ${{ github.ref == 'refs/heads/main' && format('{0}:main', steps.meta.outputs.image) || '' }}

--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -1,0 +1,57 @@
+name: Build Image
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: build-image-praxis
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    name: Build and push image
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.meta.outputs.image }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Compute lowercased image path
+        id: meta
+        run: |
+          set -euo pipefail
+          image_lc="${REGISTRY}/$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')"
+          echo "image=${image_lc}" >> "$GITHUB_OUTPUT"
+          echo "resolved image: ${image_lc}"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          build-args: |
+            GIT_SHA=${{ github.sha }}
+          tags: |
+            ${{ steps.meta.outputs.image }}:sha-${{ github.sha }}
+            ${{ steps.meta.outputs.image }}:main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.50.0 on 5th of May, 2026
+
+- Add [`.github/workflows/build_image.yml`](.github/workflows/build_image.yml) — builds the existing `Dockerfile` on push to main (and on `workflow_dispatch`), tags `ghcr.io/vaquum/praxis:sha-<commit>` and `:main`, pushes to GHCR via `docker/login-action@v3` + `docker/build-push-action@v6`. Auth uses `secrets.GITHUB_TOKEN` against the calling workflow's identity. Mirrors the build-job pattern from `Vaquum/experiment_runner`'s `deploy.yml` minus the deploy-to-host step (deferred until the operator runbook for `/opt/praxis/` lands)
+- Bump `vaquum-nexus` git+https pin from Nexus 0.38.0 main HEAD `1097d18e7e5a29ffcb212dee33b703e31f5c39ac` to Nexus 0.39.0 main HEAD `52ed0f0a4b7859b941191f85b73f4aaa22911226` (Vaquum/Nexus#59 — example `logreg_binary_evsfd` strategy + manifest + README for paper-trade bring-up under `examples/`)
+- Verified locally: `docker build -t praxis-test:local .` succeeds in ~6 minutes, all four wheels (`vaquum-praxis-0.50.0`, `vaquum-nexus-0.39.0`, `vaquum_limen-2.4.3`, `binancial-0.2.2`) build cleanly; `docker run --rm praxis-test:local --help` reaches the env-check stage and fails as expected with `RuntimeError: missing required env vars: EPOCH_ID, TRADE_MODE, MANIFESTS_DIR, STRATEGIES_BASE_PATH, STATE_BASE`
+
 ## v0.1.0 on 23rd of February, 2026
 
 - Add Binance Spot testnet connectivity verification tests in [`tests/testnet/`](tests/testnet/)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## v0.50.0 on 5th of May, 2026
-
-- Add [`.github/workflows/build_image.yml`](.github/workflows/build_image.yml) — builds the existing `Dockerfile` on push to main (and on `workflow_dispatch`), tags `ghcr.io/vaquum/praxis:sha-<commit>` and `:main`, pushes to GHCR via `docker/login-action@v3` + `docker/build-push-action@v6`. Auth uses `secrets.GITHUB_TOKEN` against the calling workflow's identity. Mirrors the build-job pattern from `Vaquum/experiment_runner`'s `deploy.yml` minus the deploy-to-host step (deferred until the operator runbook for `/opt/praxis/` lands)
-- Bump `vaquum-nexus` git+https pin from Nexus 0.38.0 main HEAD `1097d18e7e5a29ffcb212dee33b703e31f5c39ac` to Nexus 0.39.0 main HEAD `52ed0f0a4b7859b941191f85b73f4aaa22911226` (Vaquum/Nexus#59 — example `logreg_binary_evsfd` strategy + manifest + README for paper-trade bring-up under `examples/`)
-- Verified locally: `docker build -t praxis-test:local .` succeeds in ~6 minutes, all four wheels (`vaquum-praxis-0.50.0`, `vaquum-nexus-0.39.0`, `vaquum_limen-2.4.3`, `binancial-0.2.2`) build cleanly; `docker run --rm praxis-test:local --help` reaches the env-check stage and fails as expected with `RuntimeError: missing required env vars: EPOCH_ID, TRADE_MODE, MANIFESTS_DIR, STRATEGIES_BASE_PATH, STATE_BASE`
-
 ## v0.1.0 on 23rd of February, 2026
 
 - Add Binance Spot testnet connectivity verification tests in [`tests/testnet/`](tests/testnet/)
@@ -606,3 +600,9 @@
 - Fix [`MarketDataPoller.get_market_data`](praxis/market_data_poller.py) returning the previous DataFrame indefinitely after `_fetch` swallowed exceptions — strategies and `fallback_price_provider` could trade on hours-old klines after Binance public REST/testnet outages with no signal (round-18 MAJOR-005)
 - Fix [`Launcher._append_outcome_acked`](praxis/launcher.py) reaching into `Trading._event_spine` private attribute; switched to the public `Trading.event_spine` property (Greybeard pre-PR review)
 - Bump version to `0.49.0`
+
+## v0.50.0 on 5th of May, 2026
+
+- Add [`.github/workflows/build_image.yml`](.github/workflows/build_image.yml) — builds the existing `Dockerfile` on push to main (and on `workflow_dispatch`), pushes to `ghcr.io/vaquum/praxis` via `docker/login-action@v3` + `docker/build-push-action@v6` with GitHub Actions docker layer caching (`cache-from: type=gha` + `cache-to: type=gha,mode=max`). Tagging: `:sha-<commit>` is always published; `:<version>` (parsed from `pyproject.toml`'s `version = ...` field) and `:main` are published only when `github.ref == 'refs/heads/main'` so a `workflow_dispatch` from a feature branch cannot overwrite the floating tags with a non-main image. Auth uses `secrets.GITHUB_TOKEN` against the calling workflow's identity. Mirrors the build-job pattern from `Vaquum/experiment_runner`'s `deploy.yml` minus the deploy-to-host step (deferred until the operator runbook for `/opt/praxis/` lands)
+- Bump `vaquum-nexus` git+https pin from Nexus 0.38.0 main HEAD `1097d18e7e5a29ffcb212dee33b703e31f5c39ac` to Nexus 0.39.0 main HEAD `52ed0f0a4b7859b941191f85b73f4aaa22911226` (Vaquum/Nexus#59 — example `logreg_binary_evsfd` strategy + manifest + README for paper-trade bring-up under `examples/`)
+- Bump version to `0.50.0`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 ]
 license = { text = "MIT" }
 requires-python = ">=3.12"
-dependencies = ["structlog>=24.1", "orjson>=3.10", "aiosqlite>=0.20", "aiohttp>=3.10", "polars>=1.0", "pandas>=2.0", "binancial @ git+https://github.com/Vaquum/Binancial@0118288f1c79939daf8872c828b262f648110dd0", "vaquum_limen @ git+https://github.com/Vaquum/Limen@v2.4.3", "vaquum-nexus @ git+https://github.com/Vaquum/Nexus@1097d18e7e5a29ffcb212dee33b703e31f5c39ac"]
+dependencies = ["structlog>=24.1", "orjson>=3.10", "aiosqlite>=0.20", "aiohttp>=3.10", "polars>=1.0", "pandas>=2.0", "binancial @ git+https://github.com/Vaquum/Binancial@0118288f1c79939daf8872c828b262f648110dd0", "vaquum_limen @ git+https://github.com/Vaquum/Limen@v2.4.3", "vaquum-nexus @ git+https://github.com/Vaquum/Nexus@52ed0f0a4b7859b941191f85b73f4aaa22911226"]
 
 [project.optional-dependencies]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum-praxis"
-version = "0.49.0"
+version = "0.50.0"
 description = "Execution system for Vaquum — Trading sub-system + Account sub-system."
 readme = "README.md"
 authors = [


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

First step of the paper-trade deployment critical path: gives Praxis a CI workflow that builds the existing `Dockerfile` and publishes to GHCR, plus bumps the Nexus pin to pick up the example strategy bundle that just landed on the Nexus side. Bumps `vaquum-praxis` 0.49.0 → 0.50.0.

**Workflow** — adds [`.github/workflows/build_image.yml`](.github/workflows/build_image.yml). On `push` to main and `workflow_dispatch`, runs `docker/build-push-action@v6` on the existing `Dockerfile`, logs into GHCR via `secrets.GITHUB_TOKEN`, and publishes to `ghcr.io/vaquum/praxis`. Three tags per build: `:sha-<commit>` (immutable per-commit), `:<version>` (parsed from `pyproject.toml`'s `version = ...` field — fail-fast in the step if parsing returns empty), and `:main` (floating "latest stable" on main). Layer caching via `cache-from: type=gha` + `cache-to: type=gha,mode=max` so subsequent pushes don't re-download tensorflow / xgboost / scipy from scratch. Concurrency group `build-image-praxis` with `cancel-in-progress: false` so every commit's image actually publishes (no losing intermediate builds when several PRs land back-to-back). Mirrors the build-job pattern from [`Vaquum/experiment_runner`'s `deploy.yml`](https://github.com/Vaquum/experiment_runner/blob/main/.github/workflows/deploy.yml) minus the deploy-to-host step (deferred until the operator runbook for `/opt/praxis/` lands).

**Nexus pin bump** — `vaquum-nexus` git+https pin moves from Nexus 0.38.0 main HEAD `1097d18e7e5a29ffcb212dee33b703e31f5c39ac` to Nexus 0.39.0 main HEAD `52ed0f0a4b7859b941191f85b73f4aaa22911226`. The new Nexus contains [Vaquum/Nexus#59](https://github.com/Vaquum/Nexus/pull/59) — the example `logreg_binary_evsfd` strategy + manifest + README under `examples/` (closes Vaquum/Nexus#33). The strategy is the one we'll feed the Praxis launcher with at deploy time; no Praxis code change is required to consume it because the launcher already loads any manifest from `MANIFESTS_DIR`.

**Pre-PR pass.** Greybeard returned `mediocre` with 4 gripes; all 4 fixed in commit `3643a8b` before opening: (1) CHANGELOG bullet 3 was past-tense verification commentary instead of an imperative change record — bullet dropped, content moved here; (2) `build_image.yml` passed `build-args: GIT_SHA=...` to Docker but the Dockerfile has no `ARG GIT_SHA` declaration — the dead build-arg was silently dropped, removed from the workflow; (3) workflow had no GitHub Actions docker layer cache — added `cache-from: type=gha` + `cache-to: type=gha,mode=max`; (4) workflow tagged only `:sha-<commit>` and `:main` despite the same diff bumping the version — added a `Read version from pyproject.toml` step and a `:<version>` tag. No rebuttals.

**Verification.** Pure-CI / dependency PR — no Praxis source changed, so `pytest` / `ruff` / `mypy` exercise the existing test suite against the new Nexus pin. Locally verified: `docker build -t praxis-test:local .` succeeds (~6 minutes, ~1.9 GB image), all four wheels build cleanly (`vaquum-praxis-0.50.0`, `vaquum-nexus-0.39.0`, `vaquum_limen-2.4.3`, `binancial-0.2.2`); `docker run --rm praxis-test:local --help` reaches the env-check stage and fails as expected with `RuntimeError: missing required env vars: EPOCH_ID, TRADE_MODE, MANIFESTS_DIR, STRATEGIES_BASE_PATH, STATE_BASE` — confirming the full import chain through Nexus + Limen + Binancial is intact under the new pin. Once this PR merges, the workflow will fire on the merge commit, publish `ghcr.io/vaquum/praxis:sha-<merge>`, `:0.50.0`, and `:main`, and the deployment server can `docker pull` for the next step in the runbook.

**`vaquum-nexus` pin status.** Bumped to Nexus 0.39.0 main HEAD `52ed0f0a4b7859b941191f85b73f4aaa22911226`.

## Checklist

- [x] I have reviewed full diff in "Files changed"
- [x] I left no unnecessary files in the changes
- [ ] I ran \`python tests/run.py\` locally without errors (where applicable)
- [ ] I updated \`/docs\` (if behavior/API/config/user/etc changed)
- [ ] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md
- [x] I updated pyproject.toml
- [ ] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [ ] I linked issue to auto-close on merge (e.g., "Fixes #123") when applicable