### PR TITLE
chore: bump vaquum-nexus pin to 0.47.0 (v0.59.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -692,3 +692,7 @@
 - Fix [`configure_logging`](praxis/infrastructure/observability.py) to add `structlog.stdlib.ExtraAdder()` to `ProcessorFormatter.foreign_pre_chain` so stdlib `_log.info('msg', extra={...})` payloads survive into JSON output instead of being silently dropped
 - Add structured logging emit sites to [`EventSpine`](praxis/infrastructure/event_spine.py): schema-ensured info, append debug, dedup warning, fill-atomic rollback exception
 - Add `test_stdlib_extras_appear_in_json` regression test in [`tests/test_observability.py`](tests/test_observability.py)
+
+## v0.59.4 on 13th of May, 2026
+
+- Bump `vaquum-nexus` git+https pin from Nexus 0.46.0 main HEAD `b075042aa0cd5aad6da8355ce7d672983fb71eb1` to Nexus 0.47.0 main HEAD `902c895f8151318b285c64f6242cad62b720457a` ([Vaquum/Nexus#67](https://github.com/Vaquum/Nexus/pull/67) — ExtraAdder fix in `nexus/infrastructure/observability.py` + per-action `bound_context` wrapping in `submit_actions`). Pairs with the Praxis-side ExtraAdder fix in v0.59.3 so both observability modules in the deployed image honour stdlib `_log.info('msg', extra={...})` extras and the Nexus-side trade-lifecycle emits carry `strategy_id` / `action_type` / `trade_id` / `command_id` via structlog contextvars

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum-praxis"
-version = "0.59.3"
+version = "0.59.4"
 description = "Execution system for Vaquum — Trading sub-system + Account sub-system."
 readme = "README.md"
 authors = [
@@ -12,7 +12,7 @@ authors = [
 ]
 license = { text = "MIT" }
 requires-python = ">=3.12"
-dependencies = ["structlog>=24.1", "orjson>=3.10", "aiosqlite>=0.20", "aiohttp>=3.10", "polars>=1.0", "pandas>=2.0", "binancial @ git+https://github.com/Vaquum/Binancial@0118288f1c79939daf8872c828b262f648110dd0", "vaquum_limen @ git+https://github.com/Vaquum/Limen@v3.0.6", "vaquum-nexus @ git+https://github.com/Vaquum/Nexus@b075042aa0cd5aad6da8355ce7d672983fb71eb1"]
+dependencies = ["structlog>=24.1", "orjson>=3.10", "aiosqlite>=0.20", "aiohttp>=3.10", "polars>=1.0", "pandas>=2.0", "binancial @ git+https://github.com/Vaquum/Binancial@0118288f1c79939daf8872c828b262f648110dd0", "vaquum_limen @ git+https://github.com/Vaquum/Limen@v3.0.6", "vaquum-nexus @ git+https://github.com/Vaquum/Nexus@902c895f8151318b285c64f6242cad62b720457a"]
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

Bumps the `vaquum-nexus` git+https pin from Nexus 0.46.0 main HEAD `b075042aa0cd5aad6da8355ce7d672983fb71eb1` to Nexus 0.47.0 main HEAD `902c895f8151318b285c64f6242cad62b720457a` (Vaquum/Nexus#67 — ExtraAdder fix in `nexus/infrastructure/observability.py` and per-action `bound_context` wrapping in `submit_actions`). Pairs with the Praxis-side ExtraAdder fix in v0.59.3 so both observability modules in the deployed image honour stdlib `_log.info('msg', extra={...})` extras and the Nexus-side trade-lifecycle emits carry `strategy_id` / `action_type` / `trade_id` / `command_id` via structlog contextvars. Bumps to v0.59.4.

## Checklist

- [x] I have reviewed full diff in "Files changed"
- [x] I left no unnecessary files in the changes
- [x] I ran `python -m pytest` locally without errors (1038 passed, 1 skipped against the new pin)
- [ ] I updated `/docs` (if behavior/API/config/user/etc changed)
- [ ] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md
- [x] I updated pyproject.toml
- [ ] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [ ] I linked issue to auto-close on merge (e.g., "Fixes #123") when applicable