### PR TITLE
fix: decay BinanceAdapter._used_weight to release stale mode lock (v0.59.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -696,3 +696,8 @@
 ## v0.59.4 on 13th of May, 2026
 
 - Bump `vaquum-nexus` git+https pin from Nexus 0.46.0 main HEAD `b075042aa0cd5aad6da8355ce7d672983fb71eb1` to Nexus 0.47.0 main HEAD `902c895f8151318b285c64f6242cad62b720457a` ([Vaquum/Nexus#67](https://github.com/Vaquum/Nexus/pull/67) — ExtraAdder fix in `nexus/infrastructure/observability.py` + per-action `bound_context` wrapping in `submit_actions`). Pairs with the Praxis-side ExtraAdder fix in v0.59.3 so both observability modules in the deployed image honour stdlib `_log.info('msg', extra={...})` extras and the Nexus-side trade-lifecycle emits carry `strategy_id` / `action_type` / `trade_id` / `command_id` via structlog contextvars
+
+## v0.59.5 on 14th of May, 2026
+
+- Fix [`BinanceAdapter._used_weight`](praxis/infrastructure/binance_adapter.py) to decay linearly to zero over 60s (Binance's per-IP sliding window). Pre-patch a startup `load_filters` burst pinned the value at the testnet weight limit, kept `HealthEvaluator` returning REDUCE_ONLY, and blocked every ENTER with `INTAKE_MODE_BLOCKS_ENTER` for 4+ hours
+- Add three regression tests in [`tests/test_binance_adapter.py`](tests/test_binance_adapter.py) covering full decay past window, linear midpoint, and the exact 2026-05-14 pinned-mode failure mode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -699,5 +699,5 @@
 
 ## v0.59.5 on 14th of May, 2026
 
-- Fix [`BinanceAdapter._used_weight`](praxis/infrastructure/binance_adapter.py) to decay linearly to zero over 60s (Binance's per-IP sliding window). Pre-patch a startup `load_filters` burst pinned the value at the testnet weight limit, kept `HealthEvaluator` returning REDUCE_ONLY, and blocked every ENTER with `INTAKE_MODE_BLOCKS_ENTER` for 4+ hours
-- Add three regression tests in [`tests/test_binance_adapter.py`](tests/test_binance_adapter.py) covering full decay past window, linear midpoint, and the exact 2026-05-14 pinned-mode failure mode
+- Fix [`BinanceAdapter._used_weight`](praxis/infrastructure/binance_adapter.py) to step-down to zero after Binance's 60s per-IP sliding window elapses (held unchanged within the window). Pre-patch a startup `load_filters` burst pinned the value at the testnet weight limit, kept `HealthEvaluator` returning REDUCE_ONLY, and blocked every ENTER with `INTAKE_MODE_BLOCKS_ENTER` for 4+ hours
+- Add three regression tests in [`tests/test_binance_adapter.py`](tests/test_binance_adapter.py) covering drop-to-zero past window, hold-pinned within window, and the exact 2026-05-14 pinned-mode failure mode

--- a/praxis/infrastructure/binance_adapter.py
+++ b/praxis/infrastructure/binance_adapter.py
@@ -86,6 +86,7 @@ _DEFAULT_ORDER_COUNT_LIMIT = 10
 _RATE_LIMIT_WARN_THRESHOLD = 0.2
 _WEIGHT_INTERVAL_NUM = 1
 _ORDER_COUNT_INTERVAL_NUM = 10
+_WEIGHT_WINDOW_SECONDS = 60.0
 
 _log = logging.getLogger(__name__)
 
@@ -170,6 +171,7 @@ class BinanceAdapter:
         self._closed: bool = False
         self._filters: dict[str, SymbolFilters] = {}
         self._used_weight: int = 0
+        self._weight_updated_at: float = time.monotonic()
         self._weight_limit: int = _DEFAULT_WEIGHT_LIMIT
         self._order_count: dict[str, int] = {}
         self._order_count_limit: int = _DEFAULT_ORDER_COUNT_LIMIT
@@ -179,6 +181,39 @@ class BinanceAdapter:
         }
         self._clock_drift_ms: float = 0.0
         self._health_lock = threading.Lock()
+
+    def _decayed_used_weight(self) -> int:
+
+        '''
+        Time-decayed `_used_weight` modeling Binance's 1-minute sliding window.
+
+        `_used_weight` is set from the `X-MBX-USED-WEIGHT-1M` response
+        header, which reflects the venue-side count of weight consumed
+        in the trailing 60 seconds. Without fresh responses to refresh
+        the header, the local copy stays stuck at its last value while
+        the venue-side count drains. A startup spike (e.g. `load_filters`
+        bursting past the testnet 6000/min limit) would otherwise pin
+        the cached value at the limit indefinitely, tripping
+        `HealthEvaluator.headroom_breach` (default 0.85) on every
+        HealthLoop tick and locking the operational mode in
+        REDUCE_ONLY for the rest of the process lifetime — every
+        downstream ENTER then fails validation with
+        `INTAKE_MODE_BLOCKS_ENTER`. Linear decay-to-zero across
+        `_WEIGHT_WINDOW_SECONDS` matches the venue-side semantics
+        closely enough to release the mode lock once the venue's
+        actual window has rolled forward.
+
+        Returns:
+            int: Decayed weight count, or `_used_weight` unchanged when
+                a fresh header arrived less than `_WEIGHT_WINDOW_SECONDS`
+                ago (linear decay) or zero when older.
+        '''
+
+        elapsed = time.monotonic() - self._weight_updated_at
+        if elapsed >= _WEIGHT_WINDOW_SECONDS:
+            return 0
+        decay_fraction = elapsed / _WEIGHT_WINDOW_SECONDS
+        return max(0, int(self._used_weight * (1.0 - decay_fraction)))
 
     @property
     def weight_headroom(self) -> float:
@@ -193,7 +228,7 @@ class BinanceAdapter:
         if self._weight_limit <= 0:
             return 1.0
 
-        return min(1.0, max(0.0, (self._weight_limit - self._used_weight) / self._weight_limit))
+        return min(1.0, max(0.0, (self._weight_limit - self._decayed_used_weight()) / self._weight_limit))
 
     def order_count_headroom(self, account_id: str) -> float:
 
@@ -1584,7 +1619,7 @@ class BinanceAdapter:
         if self._weight_limit <= 0:
             return 0.0
 
-        return min(1.0, max(0.0, self._used_weight / self._weight_limit))
+        return min(1.0, max(0.0, self._decayed_used_weight() / self._weight_limit))
 
     @property
     def clock_drift_ms(self) -> float:
@@ -1686,6 +1721,7 @@ class BinanceAdapter:
                 parsed_weight = int(weight_raw)
                 if parsed_weight >= 0:
                     self._used_weight = parsed_weight
+                    self._weight_updated_at = time.monotonic()
 
         if account_id is not None:
             order_raw = response.headers.get('X-MBX-ORDER-COUNT-10S')

--- a/praxis/infrastructure/binance_adapter.py
+++ b/praxis/infrastructure/binance_adapter.py
@@ -185,7 +185,7 @@ class BinanceAdapter:
     def _decayed_used_weight(self) -> int:
 
         '''
-        Time-decayed `_used_weight` modeling Binance's 1-minute sliding window.
+        Step-down model for `_used_weight` against Binance's 1-minute window.
 
         `_used_weight` is set from the `X-MBX-USED-WEIGHT-1M` response
         header, which reflects the venue-side count of weight consumed
@@ -198,22 +198,29 @@ class BinanceAdapter:
         HealthLoop tick and locking the operational mode in
         REDUCE_ONLY for the rest of the process lifetime — every
         downstream ENTER then fails validation with
-        `INTAKE_MODE_BLOCKS_ENTER`. Linear decay-to-zero across
-        `_WEIGHT_WINDOW_SECONDS` matches the venue-side semantics
-        closely enough to release the mode lock once the venue's
-        actual window has rolled forward.
+        `INTAKE_MODE_BLOCKS_ENTER`.
+
+        Step-down (not linear decay): the value is held unchanged for
+        the full `_WEIGHT_WINDOW_SECONDS` window, then drops to zero.
+        This matches the venue-side behaviour for the failure mode
+        being fixed — a one-shot burst at t=0 keeps the venue's
+        sliding-window count at ~burst-size for nearly the full 60s
+        before the burst rolls off in one block. Linear decay would
+        report sub-breach utilisation by t≈9s while the venue still
+        considers the IP at-limit, risking a re-trip on the very
+        next request and mode flapping. For sustained-traffic cases
+        the decay path is never reached because each fresh header
+        replaces `_used_weight` and resets `_weight_updated_at`.
 
         Returns:
-            int: Decayed weight count, or `_used_weight` unchanged when
-                a fresh header arrived less than `_WEIGHT_WINDOW_SECONDS`
-                ago (linear decay) or zero when older.
+            int: `_used_weight` unchanged when the last header arrived
+                less than `_WEIGHT_WINDOW_SECONDS` ago, otherwise zero.
         '''
 
         elapsed = time.monotonic() - self._weight_updated_at
         if elapsed >= _WEIGHT_WINDOW_SECONDS:
             return 0
-        decay_fraction = elapsed / _WEIGHT_WINDOW_SECONDS
-        return max(0, int(self._used_weight * (1.0 - decay_fraction)))
+        return self._used_weight
 
     @property
     def weight_headroom(self) -> float:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum-praxis"
-version = "0.59.4"
+version = "0.59.5"
 description = "Execution system for Vaquum — Trading sub-system + Account sub-system."
 readme = "README.md"
 authors = [

--- a/tests/test_binance_adapter.py
+++ b/tests/test_binance_adapter.py
@@ -1794,14 +1794,16 @@ class TestHeadroom:
         adapter = _make_adapter()
         adapter._weight_limit = 1000
         adapter._used_weight = 800
-        assert adapter.weight_headroom == pytest.approx(0.2)
+        adapter._weight_updated_at = time.monotonic()
+        assert adapter.weight_headroom == pytest.approx(0.2, abs=0.005)
 
     def test_weight_headroom_exhausted(self) -> None:
 
         adapter = _make_adapter()
         adapter._weight_limit = 1000
         adapter._used_weight = 1000
-        assert adapter.weight_headroom == 0.0
+        adapter._weight_updated_at = time.monotonic()
+        assert adapter.weight_headroom == pytest.approx(0.0, abs=0.005)
 
     def test_weight_headroom_zero_limit(self) -> None:
 
@@ -2740,16 +2742,55 @@ class TestHealthSignals:
         adapter = BinanceAdapter(_BASE_URL, _WS_BASE_URL, _WS_API_URL)
         adapter._used_weight = 300
         adapter._weight_limit = 1000
+        adapter._weight_updated_at = time.monotonic()
 
-        assert adapter.rate_limit_utilization == pytest.approx(0.3)
+        assert adapter.rate_limit_utilization == pytest.approx(0.3, abs=0.005)
 
     def test_rate_limit_utilization_clamps_above_one(self) -> None:
 
         adapter = BinanceAdapter(_BASE_URL, _WS_BASE_URL, _WS_API_URL)
         adapter._used_weight = 2000
         adapter._weight_limit = 1000
+        adapter._weight_updated_at = time.monotonic()
 
         assert adapter.rate_limit_utilization == 1.0
+
+    def test_rate_limit_utilization_decays_to_zero_after_window(self) -> None:
+
+        adapter = BinanceAdapter(_BASE_URL, _WS_BASE_URL, _WS_API_URL)
+        adapter._used_weight = 6091
+        adapter._weight_limit = 6000
+        adapter._weight_updated_at = time.monotonic() - 60.0
+
+        assert adapter.rate_limit_utilization == 0.0
+
+    def test_rate_limit_utilization_linear_decay_partial(self) -> None:
+
+        adapter = BinanceAdapter(_BASE_URL, _WS_BASE_URL, _WS_API_URL)
+        adapter._used_weight = 1000
+        adapter._weight_limit = 1000
+        adapter._weight_updated_at = time.monotonic() - 30.0
+
+        assert adapter.rate_limit_utilization == pytest.approx(0.5, abs=0.02)
+
+    def test_used_weight_decay_unblocks_pinned_mode(self) -> None:
+        '''Regression: post-startup-burst, mode must not stay locked.
+
+        2026-05-14: a startup `load_filters` burst pinned `_used_weight`
+        at the testnet 6000/min limit. Without decay,
+        `rate_limit_utilization` returned 1.0 forever, tripping
+        `HealthEvaluator.headroom_breach` (0.85) and locking the mode
+        in REDUCE_ONLY for 4+ hours despite zero subsequent traffic.
+        Every ENTER was rejected with `INTAKE_MODE_BLOCKS_ENTER`.
+        '''
+
+        adapter = BinanceAdapter(_BASE_URL, _WS_BASE_URL, _WS_API_URL)
+        adapter._used_weight = 6091
+        adapter._weight_limit = 6000
+        adapter._weight_updated_at = time.monotonic() - 90.0
+
+        assert adapter.rate_limit_utilization == 0.0
+        assert adapter.weight_headroom == 1.0
 
     @pytest.mark.asyncio
     async def test_successful_signed_request_records_success(self) -> None:
@@ -2783,11 +2824,12 @@ class TestHealthSignals:
         tracker.record_request(latency_ms=12.0, succeeded=True)
         adapter._used_weight = 600
         adapter._weight_limit = 1000
+        adapter._weight_updated_at = time.monotonic()
         adapter._clock_drift_ms = 8.0
 
         snapshot = adapter.get_health_snapshot(_ACCOUNT_ID)
 
-        assert snapshot.rate_limit_headroom == pytest.approx(0.6)
+        assert snapshot.rate_limit_headroom == pytest.approx(0.6, abs=0.005)
         assert snapshot.clock_drift_ms == 8.0
 
     def test_health_trackers_are_isolated_per_account(self) -> None:

--- a/tests/test_binance_adapter.py
+++ b/tests/test_binance_adapter.py
@@ -1795,7 +1795,7 @@ class TestHeadroom:
         adapter._weight_limit = 1000
         adapter._used_weight = 800
         adapter._weight_updated_at = time.monotonic()
-        assert adapter.weight_headroom == pytest.approx(0.2, abs=0.005)
+        assert adapter.weight_headroom == pytest.approx(0.2)
 
     def test_weight_headroom_exhausted(self) -> None:
 
@@ -1803,7 +1803,7 @@ class TestHeadroom:
         adapter._weight_limit = 1000
         adapter._used_weight = 1000
         adapter._weight_updated_at = time.monotonic()
-        assert adapter.weight_headroom == pytest.approx(0.0, abs=0.005)
+        assert adapter.weight_headroom == 0.0
 
     def test_weight_headroom_zero_limit(self) -> None:
 
@@ -2744,7 +2744,7 @@ class TestHealthSignals:
         adapter._weight_limit = 1000
         adapter._weight_updated_at = time.monotonic()
 
-        assert adapter.rate_limit_utilization == pytest.approx(0.3, abs=0.005)
+        assert adapter.rate_limit_utilization == pytest.approx(0.3)
 
     def test_rate_limit_utilization_clamps_above_one(self) -> None:
 
@@ -2755,7 +2755,7 @@ class TestHealthSignals:
 
         assert adapter.rate_limit_utilization == 1.0
 
-    def test_rate_limit_utilization_decays_to_zero_after_window(self) -> None:
+    def test_rate_limit_utilization_drops_to_zero_after_window(self) -> None:
 
         adapter = BinanceAdapter(_BASE_URL, _WS_BASE_URL, _WS_API_URL)
         adapter._used_weight = 6091
@@ -2764,20 +2764,28 @@ class TestHealthSignals:
 
         assert adapter.rate_limit_utilization == 0.0
 
-    def test_rate_limit_utilization_linear_decay_partial(self) -> None:
+    def test_rate_limit_utilization_holds_pinned_within_window(self) -> None:
+        '''Step-down model: value held unchanged for the full window.
+
+        Linear decay was rejected in PR #107 review (Copilot) because
+        a one-shot burst at t=0 keeps the venue's sliding-window count
+        at ~burst-size for nearly the full 60s; reporting 50% at t=30s
+        would unlock the mode while the venue still considers the IP
+        at-limit, risking re-trip and flapping.
+        '''
 
         adapter = BinanceAdapter(_BASE_URL, _WS_BASE_URL, _WS_API_URL)
         adapter._used_weight = 1000
         adapter._weight_limit = 1000
         adapter._weight_updated_at = time.monotonic() - 30.0
 
-        assert adapter.rate_limit_utilization == pytest.approx(0.5, abs=0.02)
+        assert adapter.rate_limit_utilization == 1.0
 
     def test_used_weight_decay_unblocks_pinned_mode(self) -> None:
-        '''Regression: post-startup-burst, mode must not stay locked.
+        '''Regression: post-startup-burst, mode must not stay locked forever.
 
         2026-05-14: a startup `load_filters` burst pinned `_used_weight`
-        at the testnet 6000/min limit. Without decay,
+        at the testnet 6000/min limit. Without time-based release,
         `rate_limit_utilization` returned 1.0 forever, tripping
         `HealthEvaluator.headroom_breach` (0.85) and locking the mode
         in REDUCE_ONLY for 4+ hours despite zero subsequent traffic.
@@ -2829,7 +2837,7 @@ class TestHealthSignals:
 
         snapshot = adapter.get_health_snapshot(_ACCOUNT_ID)
 
-        assert snapshot.rate_limit_headroom == pytest.approx(0.6, abs=0.005)
+        assert snapshot.rate_limit_headroom == pytest.approx(0.6)
         assert snapshot.clock_drift_ms == 8.0
 
     def test_health_trackers_are_isolated_per_account(self) -> None:


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

Fixes a latent bug that surfaced in production on 2026-05-14: a startup `load_filters` burst tripped the Binance testnet 6000/min weight limit, leaving `BinanceAdapter._used_weight` pinned at the limit. Because `_used_weight` was only refreshed from `X-MBX-USED-WEIGHT-1M` response headers, and every subsequent ENTER was being blocked (so no fresh headers arrived), `rate_limit_utilization` stayed at `1.0` forever. `HealthEvaluator.headroom_breach` (0.85) kept tripping on every HealthLoop tick, `state.mode` stayed locked at REDUCE_ONLY, and every downstream ENTER from all 4 stub strategies + `logreg_binary_evsfd` failed validation with `INTAKE_MODE_BLOCKS_ENTER` for 4+ hours despite zero subsequent venue traffic. Adds `_decayed_used_weight()` that uses a **step-down** model: holds `_used_weight` unchanged for the full `_WEIGHT_WINDOW_SECONDS = 60.0` window, then drops to zero. Step-down (not linear decay) matches Binance's sliding-window behaviour for one-shot bursts — the venue keeps the count at ~burst-size for nearly the full 60s before the burst rolls off in one block. Linear decay would report sub-breach utilisation by t≈9s while the venue still considers the IP at-limit, risking re-trip and mode flapping. `weight_headroom` and `rate_limit_utilization` both consume the stepped value. `_weight_updated_at` is set on every fresh header parse so the elapsed-time clock tracks the actual data refresh, not process uptime. Three regression tests in `tests/test_binance_adapter.py` cover drop-to-zero past window, hold-pinned within window, and the exact 2026-05-14 pinned-mode failure mode. Bumps to v0.59.5.

## Checklist

- [x] I have reviewed full diff in "Files changed"
- [x] I left no unnecessary files in the changes
- [x] I ran \`python -m pytest\` locally without errors (1041 passed, 1 skipped)
- [ ] I updated \`/docs\` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md
- [x] I updated pyproject.toml
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [ ] I linked issue to auto-close on merge (e.g., "Fixes #123") when applicable