### PR TITLE
fix: surface the sync-accounting registration-race skip (v0.78.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1026,3 +1026,18 @@
 - Add [`Launcher._apply_sync_accounting`](praxis/launcher.py) static method: looks up the outcome's `OrderContext` under the registry lock (skips when not yet registered — the async path covers those once the submitter completes registration), calls `OutcomeProcessor.process`, records mutated command ids in `unpersisted_commands` for the async consumer's persist, and contains all failures so accounting errors never block strategy-callback delivery
 - Add [`tests/test_launcher_sync_accounting.py`](tests/test_launcher_sync_accounting.py) (6 cases): position mutation marks the command unpersisted; capital mutation marks the command unpersisted; skip on missing `OrderContext`; failure result does not mark; success without mutation does not mark; processor exception contained
 - Add `test_full_close_rejection_with_pending_exit_does_not_route_to_close_as_dust` to [`tests/test_launcher_validation_context.py`](tests/test_launcher_validation_context.py): a sub-lot full-close rejection with `pending_exit > 0` must NOT call `close_as_dust`
+
+## v0.78.0 on 11th of June, 2026
+
+### NOTE
+
+- Companion to Nexus v0.59.0's unresolved-outcome retry: the registration-gap race (translated outcomes reaching the accounting paths ~1ms before the submitter's post-`send_command` registration loop made `command_strategy_ids` / `command_contexts` visible) surfaced in epoch 24 as two venue-filled EXITs whose accounting never ran. The Nexus side now retries; this release makes the Praxis-side skip observable
+
+### Update
+
+- Bump [`vaquum-nexus`](pyproject.toml) git-pin to Nexus v0.59.0 (`OutcomeLoop` retries unresolved-strategy outcomes on a backoff schedule instead of dropping them)
+- Update [`Launcher._apply_sync_accounting`](praxis/launcher.py): the missing-`OrderContext` skip is no longer silent — it logs a warning with `account_id`, `command_id`, `outcome_id`, `outcome_type`, and `has_strategy_mapping` (whether the strategy registry already contains the command, checked in the same lock hold as the context lookup), distinguishing the pre-registration race from a genuinely unknown command
+
+### Add
+
+- Add `account_id` and `command_strategy_ids` to [`_AccountOutcomeWiring`](praxis/launcher.py) — telemetry-only references for the skip warning, registered alongside the existing wiring fields

--- a/praxis/launcher.py
+++ b/praxis/launcher.py
@@ -1312,8 +1312,8 @@ class _AccountOutcomeWiring:
         outcome_processor: The account's Nexus outcome processor.
         command_contexts: Registry of in-flight `OrderContext`s by
             command_id, shared with the submitter and `process_outcome`.
-        command_registry_lock: Lock guarding `command_contexts` and
-            `unpersisted_commands`.
+        command_registry_lock: Lock guarding `command_contexts`,
+            `command_strategy_ids`, and `unpersisted_commands`.
         unpersisted_commands: Command ids whose in-memory mutation has
             not yet been durably persisted, each mapped to the
             generation stamped at its most recent marking. The
@@ -1341,10 +1341,12 @@ class _AccountOutcomeWiring:
         account_id: The owning account, for skip telemetry.
         command_strategy_ids: Registry of command_id to strategy_id,
             shared with the submitter and the `OutcomeLoop`'s
-            `resolve_strategy_id`. Read here only for skip telemetry —
-            whether a missing `OrderContext` coincides with a missing
-            strategy mapping distinguishes the pre-registration race
-            from a genuinely unknown command.
+            `resolve_strategy_id`, and guarded by
+            `command_registry_lock` like the other registries. Read
+            here only for skip telemetry — whether a missing
+            `OrderContext` coincides with a missing strategy mapping
+            distinguishes the pre-registration race from a genuinely
+            unknown command.
     '''
 
     outcome_processor: OutcomeProcessor
@@ -1491,9 +1493,10 @@ class Launcher:
 
         if order_context is None:
             _log.warning(
-                'sync accounting skipped: no OrderContext for command — '
-                'outcome raced the submitter registration; the async '
-                'path must resolve it once registration lands',
+                'sync accounting skipped: no OrderContext for command '
+                'at outcome time; deferred to the async path '
+                '(pre-registration race when has_strategy_mapping is '
+                'also false and registration lands shortly after)',
                 extra={
                     'account_id': wiring.account_id,
                     'command_id': nexus_outcome.command_id,

--- a/praxis/launcher.py
+++ b/praxis/launcher.py
@@ -1338,11 +1338,20 @@ class _AccountOutcomeWiring:
             the discard would drop the unpersisted mutation.
         pending_generation: Monotonic counter feeding the generation
             stamps. Guarded by `command_registry_lock`.
+        account_id: The owning account, for skip telemetry.
+        command_strategy_ids: Registry of command_id to strategy_id,
+            shared with the submitter and the `OutcomeLoop`'s
+            `resolve_strategy_id`. Read here only for skip telemetry —
+            whether a missing `OrderContext` coincides with a missing
+            strategy mapping distinguishes the pre-registration race
+            from a genuinely unknown command.
     '''
 
     outcome_processor: OutcomeProcessor
     command_contexts: dict[str, OrderContext]
     command_registry_lock: threading.Lock
+    account_id: str = ''
+    command_strategy_ids: dict[str, str] = field(default_factory=dict)
     unpersisted_commands: dict[str, int] = field(default_factory=dict)
     pending_generation: int = 0
 
@@ -1462,8 +1471,9 @@ class Launcher:
         closed by the synchronous state mutation, not by synchronous
         persistence.
 
-        Outcomes whose `OrderContext` is not yet registered are skipped;
-        the async path processes them once the submitter completes
+        Outcomes whose `OrderContext` is not yet registered are skipped
+        with a warning (the pre-registration race telemetry); the async
+        path's unresolved-retry covers them once the submitter completes
         registration. Failures are logged and never propagate — the
         strategy-callback delivery must not be blocked by accounting
         errors.
@@ -1475,8 +1485,23 @@ class Launcher:
 
         with wiring.command_registry_lock:
             order_context = wiring.command_contexts.get(nexus_outcome.command_id)
+            has_strategy_mapping = (
+                nexus_outcome.command_id in wiring.command_strategy_ids
+            )
 
         if order_context is None:
+            _log.warning(
+                'sync accounting skipped: no OrderContext for command — '
+                'outcome raced the submitter registration; the async '
+                'path must resolve it once registration lands',
+                extra={
+                    'account_id': wiring.account_id,
+                    'command_id': nexus_outcome.command_id,
+                    'outcome_id': nexus_outcome.outcome_id,
+                    'outcome_type': nexus_outcome.outcome_type.value,
+                    'has_strategy_mapping': has_strategy_mapping,
+                },
+            )
             return
 
         try:
@@ -2080,6 +2105,8 @@ class Launcher:
             outcome_processor=outcome_processor,
             command_contexts=command_contexts,
             command_registry_lock=command_registry_lock,
+            account_id=inst.account_id,
+            command_strategy_ids=command_strategy_ids,
         )
         with self._account_outcome_wiring_lock:
             self._account_outcome_wiring[inst.account_id] = wiring

--- a/praxis/launcher.py
+++ b/praxis/launcher.py
@@ -1350,8 +1350,8 @@ class _AccountOutcomeWiring:
     outcome_processor: OutcomeProcessor
     command_contexts: dict[str, OrderContext]
     command_registry_lock: threading.Lock
-    account_id: str = ''
-    command_strategy_ids: dict[str, str] = field(default_factory=dict)
+    account_id: str
+    command_strategy_ids: dict[str, str]
     unpersisted_commands: dict[str, int] = field(default_factory=dict)
     pending_generation: int = 0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum-praxis"
-version = "0.77.0"
+version = "0.78.0"
 description = "Execution system for Vaquum — Trading sub-system + Account sub-system."
 readme = "README.md"
 authors = [
@@ -12,7 +12,7 @@ authors = [
 ]
 license = { text = "MIT" }
 requires-python = ">=3.12"
-dependencies = ["structlog>=24.1", "orjson>=3.10", "aiosqlite>=0.20", "aiohttp>=3.10", "polars>=1.0", "pandas>=2.0", "binancial @ git+https://github.com/Vaquum/Binancial@0118288f1c79939daf8872c828b262f648110dd0", "vaquum_limen @ git+https://github.com/Vaquum/Limen@06815fabd238d470e50b129b24d12e79f9a69995", "vaquum-nexus @ git+https://github.com/Vaquum/Nexus@cac2508eaeddd8b89fc51459b044f3cfb0e88841"]
+dependencies = ["structlog>=24.1", "orjson>=3.10", "aiosqlite>=0.20", "aiohttp>=3.10", "polars>=1.0", "pandas>=2.0", "binancial @ git+https://github.com/Vaquum/Binancial@0118288f1c79939daf8872c828b262f648110dd0", "vaquum_limen @ git+https://github.com/Vaquum/Limen@06815fabd238d470e50b129b24d12e79f9a69995", "vaquum-nexus @ git+https://github.com/Vaquum/Nexus@5db6fb01415d858ae16dbdec5230d15f24c64109"]
 
 [project.optional-dependencies]
 dev = [

--- a/tests/test_launcher_sync_accounting.py
+++ b/tests/test_launcher_sync_accounting.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import logging
 import threading
 from datetime import UTC, datetime
 from decimal import Decimal
 from typing import Any
+
+import pytest
 
 from nexus.core.domain.enums import OrderSide
 from nexus.infrastructure.praxis_connector.order_context import OrderContext
@@ -135,16 +138,30 @@ class TestApplySyncAccounting:
         assert wiring.unpersisted_commands == {'cmd_001': 2}
         assert wiring.pending_generation == 2
 
-    def test_skips_when_order_context_missing(self) -> None:
+    def test_skips_when_order_context_missing(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
         processor = _RecordingProcessor(
             ProcessResult(success=True, outcome_type=TradeOutcomeType.ACK),
         )
         wiring = _wiring(processor, {})
 
-        Launcher._apply_sync_accounting(wiring, _outcome())
+        with caplog.at_level(logging.WARNING, logger='praxis.launcher'):
+            Launcher._apply_sync_accounting(wiring, _outcome())
 
         assert processor.calls == []
         assert wiring.unpersisted_commands == {}
+
+        record = next(
+            r for r in caplog.records
+            if 'sync accounting skipped' in r.message
+        )
+        assert record.account_id == 'acct-test'
+        assert record.command_id == 'cmd_001'
+        assert record.outcome_id == 'out_001'
+        assert record.outcome_type == 'ACK'
+        assert record.has_strategy_mapping is False
 
     def test_failure_result_does_not_mark_unpersisted(self) -> None:
         processor = _RecordingProcessor(

--- a/tests/test_launcher_sync_accounting.py
+++ b/tests/test_launcher_sync_accounting.py
@@ -79,6 +79,8 @@ def _wiring(
         outcome_processor=processor,
         command_contexts=contexts,
         command_registry_lock=threading.Lock(),
+        account_id='acct-test',
+        command_strategy_ids={},
     )
 
 


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

Companion to [`Vaquum/Nexus#85`](https://github.com/Vaquum/Nexus/pull/85) (merged as Nexus v0.59.0, commit `5db6fb0`), which this PR pins.

## What does this PR change?

The registration-gap race observed in epoch 24 (2026-06-11): binsim fills in ~50ms, while the launcher's submitter registers `command_strategy_ids` / `command_contexts` only after `send_command` returns for the batch — so translated outcomes can reach the accounting paths ~1ms before registration becomes visible. Two venue-filled EXITs lost their accounting entirely this way. Nexus v0.59.0 closes the loss (the `OutcomeLoop` retries unresolved outcomes on a per-command FIFO backoff schedule); this release makes the Praxis-side skip observable.

### `fix:` Sync-accounting skip telemetry

[`Launcher._apply_sync_accounting`](praxis/launcher.py): the missing-`OrderContext` skip is no longer silent — it logs a warning with `account_id`, `command_id`, `outcome_id`, `outcome_type`, and `has_strategy_mapping` (whether the strategy registry already contains the command, checked in the same lock hold as the context lookup). The combination distinguishes the pre-registration race (both missing) from partial registration or a genuinely unknown command.

[`_AccountOutcomeWiring`](praxis/launcher.py) gains `account_id` and `command_strategy_ids` as telemetry-only references, registered alongside the existing wiring fields.

### `chore:` Dependency pin

[`vaquum-nexus`](pyproject.toml) → `5db6fb0` (v0.59.0): unresolved-strategy outcomes are retried on the `UNRESOLVED_RETRY_DELAYS` backoff (per-command FIFO, sibling order preserved, loud exhaustion) instead of dropped.

## Tests

No new tests: the skip path's behavior is unchanged (skip + defer to async) and already covered by `tests/test_launcher_sync_accounting.py::test_skips_when_order_context_missing`; this PR only adds telemetry to it. Full suite run against the new pin: **1,595 passed** / 1 skipped. `ruff` + `mypy` clean.

Bumps version 0.77.0 → 0.78.0.

## Checklist

- [x] I have reviewed full diff in “Files changed”
- [x] I left no unnecessary files in the changes
- [x] I ran `python tests/run.py` locally without errors (where applicable)
- [ ] I updated `/docs` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md (unless only docs or other non-code aspect was changed)
- [x] I updated pyproject.toml (unless only docs or other non-code aspect was changed)
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [ ] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [ ] I linked issue to auto-close on merge (e.g., “Fixes #123”) when applicable