### PR TITLE
fix: settle fills at the venue fee rate; prune the technical-debt register (v0.82.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1116,3 +1116,18 @@
 ### Remove
 
 - Remove [`praxis/market_data_cache.py`](praxis/market_data_cache.py) (`MainCache` / `CacheScheduler`) and [`praxis/market_data_poller.py`](praxis/market_data_poller.py) (`MarketDataPoller`), the launcher's `_start_poller` bootstrap, `_register_wired_kline_sizes`, and `_last_close_from_poller`; and the `vaquum_limen`, `binancial`, and `pandas` dependencies (`pandas` was used only by the removed market-data modules)
+
+## v0.82.0 on 16th of June, 2026
+
+### Add
+
+- Add `TestLauncherFeeRateWiring` to [`tests/test_launcher.py`](tests/test_launcher.py) asserting the launcher wires the outcome translator with `_DEFAULT_FEE_RATE` (and that the rate is positive)
+- Add TD-095 to [`docs/TechnicalDebt.md`](docs/TechnicalDebt.md): the outcome translator re-derives `actual_fees` from the constant `_DEFAULT_FEE_RATE` rather than the venue-reported `FillReceived.fee` — exact for binsim's flat 10 bps, an approximation on a venue with a maker/taker split or fee discounts
+
+### Fix
+
+- Construct [`OutcomeTranslator`](praxis/outcome_translator.py) with `fee_rate=_DEFAULT_FEE_RATE` in the launcher instead of the zero-fee default: settled-fill `actual_fees` forwarded to Nexus now match the venue charge and the reservation-time fee estimate (both already use `_DEFAULT_FEE_RATE` = 0.10%), so realized PnL and capital release account for fees instead of treating trading as fee-free. The previous zero default was a testnet-era assumption that no longer holds against a fee-charging venue. Resolves TD-030; with `actual_fees` non-zero, Nexus's existing `realized_pnl = gross_pnl - actual_fees` (TD-051) takes effect
+
+### Remove
+
+- Prune the technical-debt register in [`docs/TechnicalDebt.md`](docs/TechnicalDebt.md): collapse code-verified-resolved (TD-009, TD-020, TD-030, TD-045) and Conduit-obsoleted (TD-019, TD-060, TD-061, TD-062) entries to heading-only status markers, and reframe TD-053 around the Conduit/Arrow feed-staleness path that replaced `MarketDataPoller`

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -146,16 +146,7 @@ When a duplicate Praxis terminal outcome arrives for a `command_id` that has alr
 
 ---
 
-## TD-030: `OutcomeTranslator` `fee_rate=0` latent inconsistency with capital reserve estimate
-
-**Origin**: Round-13 audit, re-verified round-14
-**Severity**: Low (latent; safe under fee_rate=0)
-**Module**: `praxis/launcher.py:1037` (translator default `fee_rate=_ZERO`); `praxis/launcher.py:105` (`_DEFAULT_FEE_RATE = Decimal('0.001')` for capital reserve estimate)
-
-Capital reserve at action-submit time uses `_DEFAULT_FEE_RATE = 0.001`. Translator emits `actual_fees=0` because `fee_rate=_ZERO`. `order_fill` reconciles via the `fee_delta > 0` branch (`capital_controller.py:759-760`). Currently safe. If a future deployment switches `OutcomeTranslator.fee_rate` to non-zero AND the venue actually charges more than estimated, `fee_delta < 0` and `abs(fee_delta) > fee_reserve` (which starts at zero) → `order_fill` returns `EXPECTED_MISS` → position FAILS to grow on FILL → silent state drift.
-
-**When to fix**: Before any deployment switches `OutcomeTranslator.fee_rate` to non-zero. Couples with Nexus TD-051 (realized_pnl exit-fee accounting).
-**Migration**: Bring translator `fee_rate` in line with the validator's `_DEFAULT_FEE_RATE`, OR document the asymmetry and gate any future fee_rate change on a `_reduce_position` exit-fee accounting update.
+## TD-030: `OutcomeTranslator` `fee_rate=0` latent inconsistency with capital reserve estimate — RESOLVED
 
 ---
 
@@ -831,3 +822,16 @@ Option 1 is the minimum-change path if `Ledger.fills` is confirmed never-read in
 ## TD-082: `Launcher.build_context` closure late-binds `outcome_processor` (RESOLVED in v0.76.0)
 
 **Resolved** in v0.76.0 during PR review (Vaquum/Praxis#143, round 4). The launcher now pre-binds `outcome_processor: OutcomeProcessor | None = None` above the `build_context` closure definition; the later `outcome_processor = OutcomeProcessor(...)` reassigns the same name and the closure resolves it at call time. The `UnboundLocalError` hazard no longer exists on any startup-order refactor. Entry retained as historical record.
+
+---
+
+## TD-095: `OutcomeTranslator` re-derives `actual_fees` from a constant rate, not the venue fill fee
+
+**Origin**: Fee-accounting fix (post-Conduit), Greybeard pre-PR review
+**Severity**: Low (exact for binsim's flat 10 bps; diverges only on a variable-fee venue)
+**Module**: `praxis/outcome_translator.py`
+
+`_build_partial` / `_build_filled` compute `actual_fees = delta_notional * self._fee_rate` from a single `fee_rate` (now `_DEFAULT_FEE_RATE` = 0.001). The venue's own per-fill fee is present on `FillReceived.fee` but is not threaded into the Praxis `TradeOutcome` aggregate the translator consumes, so it cannot be passed through. For binsim's flat 10 bps taker fee the constant is exact; on a venue with a maker/taker split, tiered fees, or a BNB discount, the re-derived `actual_fees` diverges from the true fill fee and mis-states realized PnL by the difference.
+
+**When to fix**: Before mainnet, OR when maker orders / fee tiers are in use.
+**Migration**: Thread the venue-reported `fee` (and `fee_asset`) from `FillReceived` through `Order` and the Praxis `TradeOutcome` aggregate into the translator, and emit it verbatim as `actual_fees` instead of re-deriving from `fee_rate`.

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -34,16 +34,7 @@ Known technical debt in shipped code. Each item includes origin PR, severity, an
 
 ---
 
-## TD-019: MarketDataPoller refetches the full window on every tick
-
-**Origin**: PR #72 (PR review)
-**Severity**: Low for MMVP paper trading; moderate at production cadence
-**Module**: `praxis/market_data_poller.py`
-
-`_fetch()` computes `start_date` as `now - n_rows * kline_size` on every poll and refetches the full window (default `n_rows=5000`). At short polling intervals this generates unnecessary REST traffic and can press against Binance rate limits once multiple `kline_size` buckets or multiple accounts share the poller. The current behavior predates this PR; the binancial migration preserved the same pattern.
-
-**When to fix**: Before increasing poll frequency, adding multiple `kline_size` buckets, or going live on mainnet.
-**Migration**: Track the highest `close_time` already in `_data[kline_size]` and refetch only from there forward, merging new rows into the in-memory DataFrame. Deduplicate on `close_time` to handle the always-partial last candle. Cap stored history at `n_rows` rolling.
+## TD-019: MarketDataPoller refetches the full window on every tick — OBSOLETE (superseded by Conduit migration)
 
 ---
 
@@ -464,24 +455,23 @@ The runtime retry handles transient callback failures; the `OutcomeAcked` event 
 
 ---
 
-## TD-053: HealthLoop demote to REDUCE_ONLY on sustained market-data failure
+## TD-053: HealthLoop demote to REDUCE_ONLY on sustained Conduit/Arrow feed staleness
 
-**Origin**: Round-18 MAJOR-005 part scope deferral (Praxis #86)
+**Origin**: Round-18 MAJOR-005 deferral (Praxis #86); reframed for the Conduit/Arrow feed after the Furnace-Conduit migration retired `MarketDataPoller`.
 **Severity**: Major (defense-in-depth on top of validator PRICE-stage rejection)
-**Module**: `praxis/market_data_poller.py`; cross-repo: `nexus/core/health_loop.py`, `praxis/core/domain/health_snapshot.py`
+**Modules**: `nexus/strategy/predict_loop.py`, `praxis/arrow_price_store.py`; cross-repo: `nexus/core/health_loop.py`, `praxis/core/domain/health_snapshot.py`
 
-MAJOR-005 landed cache-freshness enforcement (`StaleMarketDataError` from `MarketDataPoller.get_market_data` after `max_age_seconds`, default `2 * kline_size`) and `fallback_price_provider` now returns `None` on stale data, so the validator's PRICE stage rejects ENTERs cleanly. The bigger M05.4 / M05.7 acceptance — counting consecutive `_fetch` failures and surfacing them to `HealthSnapshot` so HealthLoop demotes `state.mode` to `REDUCE_ONLY` (EXITs still work, ENTERs blocked) — was scoped out because it requires plumbing a new health-signal field into `HealthSnapshot`, wiring it through the `health_snapshot_provider` callback the launcher gives to `HealthLoop`, and verifying mode-transition semantics in the cross-repo loop.
+Freshness is enforced per call site after the migration: the Conduit `PredictLoop` skips a tick when `serving_manifest.generated_at` is stale, and `ArrowPriceStore.latest_close` returns `None` when the latest closed bar exceeds `max_staleness_intervals`, so `fallback_price_provider` / `mark_price_provider` yield `None` and the validator's PRICE stage rejects ENTERs cleanly. There is still no single system-wide signal: sustained Conduit/Arrow staleness does not demote `state.mode` to `REDUCE_ONLY` (EXITs allowed, ENTERs blocked) the way a venue-feed-degraded health gate would.
 
-The current behavior is safe for paper trading: stale data raises in the predict tick (loop catches, signal skipped), and stale fallback rejects ENTER at PRICE-stage. Mode demotion would add a single coherent system-wide signal instead of relying on per-callsite rejection.
+The current behavior is safe for paper trading (stale predictions are skipped; stale mark price rejects ENTER at PRICE stage). Mode demotion would add one coherent operator-facing signal instead of relying on per-call-site rejection.
 
-**When to fix**: Before sustained mainnet operation, OR when a single operator-facing health signal is needed for "venue feed degraded; trading reduced".
+**When to fix**: Before sustained mainnet operation, OR when a single operator-facing "feed degraded; trading reduced" signal is needed.
 
 **Migration**:
-1. Add a `consecutive_fetch_failures: int` counter to `MarketDataPoller` (per-kline_size dict); reset on `_fetch` success, increment on failure.
-2. Expose `health_status() -> dict[int, MarketDataHealth]` (or similar) reporting per-kline failure counts and stale flags.
-3. Add a `market_data_healthy: bool` field to `HealthSnapshot` (Praxis-side dataclass); the launcher's `_build_health_snapshot` callback samples `MarketDataPoller.health_status()` and sets it.
-4. In Nexus `HealthLoop` / `HealthEvaluator`, add a transition: `market_data_healthy=False` → `REDUCE_ONLY` (EXITs still work, ENTERs blocked).
-5. Test: simulate repeated `_fetch` failures → after N attempts, snapshot reports unhealthy → HealthLoop demotes mode within next tick → validator's MODE stage rejects ENTERs.
+1. Track consecutive stale/missing reads in the Conduit `PredictLoop` and/or `ArrowPriceStore` (per series); reset on a fresh read, increment on stale/absent.
+2. Add a `feed_healthy: bool` field to `HealthSnapshot`; the launcher's health-snapshot callback samples the staleness counters and sets it.
+3. In Nexus `HealthLoop` / `HealthEvaluator`, add a transition: `feed_healthy=False` to `REDUCE_ONLY`.
+4. Test: simulate sustained stale Conduit manifest / Arrow frames so the snapshot reports unhealthy, HealthLoop demotes mode within the next tick, and the validator's MODE stage rejects ENTERs while EXITs still pass.
 
 ---
 
@@ -594,55 +584,15 @@ Between `await session.ws_connect(ws_api_url)` and the success-path assignment `
 
 ---
 
-## TD-060: `MarketDataPoller` test cleanup not protected by `try/finally`
-
-**Origin**: Copilot review on PR #103 (fix/poller-fixed-cadence)
-**Severity**: Low (test hygiene; theoretical pollution risk, never observed)
-**Module**: `tests/test_market_data_poller.py` — 18 of 20 `poller.start()` callsites
-
-Most `MarketDataPoller` tests follow the pattern `poller.start(); ...assertions...; poller.stop()` without a `try/finally` guard between them. If any assertion in the middle raises, `poller.stop()` is skipped and the daemon poller thread leaks for the rest of the pytest session. Once the calling test's `with patch('...get_spot_klines', ...)` context exits, the leaked thread reverts to the real `get_spot_klines` import and starts hitting Binance for real. The next test that patches the same symbol then sees its mock's `call_count` bumped by the leaked thread, causing flake.
-
-The risk is real but theoretical: 18 unprotected sites have run consistently green across many CI cycles. Copilot flagged 3 specific instances on PR #103 but the lack of `try/finally` is the project-wide convention in this file, not a regression introduced by that PR.
-
-**When to fix**: When a `poller.*` test starts flaking in CI for unexplained reasons (the leaked-thread pollution mechanism would be a candidate), OR when the next refactor of `tests/test_market_data_poller.py` happens for any other reason and the sweep cost is amortised.
-
-**Migration**: Wrap all 18 `poller.start()`-with-assertion sites in `try/finally`:
-
-```python
-poller.start()
-try:
-    ...assertions...
-finally:
-    poller.stop()
-```
-
-Or extract a small `_run_with_poller(poller, fn)` context manager / pytest fixture so individual tests don't pay the boilerplate. Keep the 2 already-wrapped sites (which use the right pattern) as the template.
+## TD-060: `MarketDataPoller` test cleanup not protected by `try/finally` — OBSOLETE (superseded by Conduit migration)
 
 ---
 
-## TD-061: Synchronous Limen + binancial fetches block `Launcher.launch()` for minutes
-
-**Severity**: Medium (operator UX; no correctness impact)
-**Module**: `praxis/launcher.py:_start_poller` (introduced by Vaquum/Praxis#108)
-
-`_start_poller` calls `MainCache.bootstrap_if_empty()` (downloads ~100MB HF snapshot when the disk parquet is missing) and `MainCache.refresh_from_binancial()` (walks Binance trades for the trailing window) synchronously inline in `launch()`. On first-ever boot, that's a few minutes of blocking work between `_start_trading` and `_start_nexus_instances` with no progress signal — `/healthz` is not yet listening either, so an operator sees a hung process. The choice was deliberate (Vaquum/Praxis#108 deploy plan) to ensure sensors see fresh data on the first tick after `_start_nexus_instances`, not 1 minute later.
-
-**When to fix**: When boot latency starts mattering for ops (e.g. faster crash-recovery cycles, or once we have a watchdog that times out the initial fill). At that point, move the synchronous `refresh_from_binancial()` out of `_start_poller` and let `CacheScheduler`'s binancial thread fire it asynchronously; sensors get fresh data on the first scheduler tick (~60s post-boot).
-
-**Migration**: Drop `self._cache.refresh_from_binancial()` from `_start_poller`. Document the new "first 60s of uptime have ≤24h-stale data" contract in the launcher docstring.
+## TD-061: Synchronous Limen + binancial fetches block `Launcher.launch()` for minutes — OBSOLETE (superseded by Conduit migration)
 
 ---
 
-## TD-062: `_aggregate_spot_klines` is a private Limen helper that Praxis depends on
-
-**Severity**: Low (coupling, no correctness impact)
-**Module**: `praxis/market_data_cache.py:30` (introduced by Vaquum/Praxis#108)
-
-`MainCache.get_market_data` calls Limen's `_aggregate_spot_klines` (imported as `_limen_aggregate_spot_klines`) to aggregate 1-min bars up to the requested kline_size. No `# noqa: PLC2701` suppression on the import: PLC2701 isn't enabled in the current ruff config (the `PL` selector in `pyproject.toml` does not activate it for this codebase's ruff version), so adding the noqa would itself trip RUF100 (unused noqa). The aliased import name keeps the cross-package private dependency visible at the call site. That function is canonical (weighted mean, sum-of-squares for std, sum for volume / liquidity / maker_volume, first / last for OHLC) and reusing it avoids drift between training-time aggregation and live aggregation — but importing a private name across packages is fragile: a Limen rename or signature change would break Praxis without a deprecation warning.
-
-**When to fix**: Either (a) ask the Limen team to expose `aggregate_spot_klines` as a public API (preferred — single source of truth), or (b) copy the function body + `_base_interval_seconds` + `_round_spot_kline_columns` helpers into Praxis (~120 LOC) and accept the drift risk.
-
-**Migration**: For (a), once Limen ships a public name, swap the import to the public symbol. For (b), copy the three functions verbatim, add a comment pointing at the upstream version + Limen pin in `pyproject.toml` so a reviewer knows to re-sync on the next Limen pin bump. If a future ruff config enables PLC2701, add the `# noqa: PLC2701` suppression at the same time as either path.
+## TD-062: `_aggregate_spot_klines` is a private Limen helper that Praxis depends on — OBSOLETE (superseded by Conduit migration)
 
 ---
 

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -4,16 +4,7 @@ Known technical debt in shipped code. Each item includes origin PR, severity, an
 
 ---
 
-## TD-009: VWAP re-read from spine on abort
-
-**Origin**: PR #52 (PR review)
-**Severity**: Low (epochs are small currently)
-**Module**: `praxis/core/execution_manager.py`
-
-`_process_abort` computes VWAP by calling `EventSpine.read()` and filtering for `FillReceived` events matching the `client_order_id`. This re-reads and rehydrates the entire epoch for every abort with fills, scaling as O(events_in_epoch). The `Order` dataclass tracks `filled_qty` but not `avg_fill_price`.
-
-**When to fix**: Before epochs grow to thousands of events or abort frequency increases.
-**Migration**: Either add cumulative notional tracking to `Order`/`TradingState` so VWAP is available without spine re-read, or add a spine query method that fetches only `FillReceived` rows for a given `client_order_id`.
+## TD-009: VWAP re-read from spine on abort — RESOLVED
 
 ---
 
@@ -56,16 +47,7 @@ Known technical debt in shipped code. Each item includes origin PR, severity, an
 
 ---
 
-## TD-020: `command_strategy_ids` registry grows unbounded per account
-
-**Origin**: PR #73 (zero-bang review)
-**Severity**: Low (negligible at MMVP throughput)
-**Module**: `praxis/launcher.py`
-
-The per-account `command_strategy_ids: dict[str, str]` registry built inside `Launcher._build_nexus_runtime` records `command_id → strategy_id` on every `SubmissionStatus.SUBMITTED` outcome from `submit_actions`, but no entry is ever removed. At MMVP testnet throughput (~100 commands/day per account) the long-run footprint is negligible (~1 MB/year), but a long-lived production process accumulating thousands of commands per day per account would eventually warrant pruning.
-
-**When to fix**: Before sustained mainnet operation past a few weeks per process.
-**Migration**: Have the OutcomeLoop drop `command_strategy_ids[outcome.command_id]` after dispatching a terminal `TradeOutcomeType` (`FILLED`, `REJECTED`, `EXPIRED`, `CANCELED`). Non-terminal outcomes (`ACK`, `PARTIAL`) keep the entry so subsequent fills still resolve.
+## TD-020: `command_strategy_ids` registry grows unbounded per account — RESOLVED
 
 ---
 
@@ -373,16 +355,7 @@ Boot reconciliation walks `trading_state.orders` (rebuilt from EventSpine) and q
 
 ---
 
-## TD-045: Symbol filters not loaded for fresh accounts; `_validate_order` fails open
-
-**Origin**: Round-18 codex-supervised audit (Pass 10)
-**Severity**: Low (Binance applies its own filter checks; rate limit waste only)
-**Module**: `praxis/trading.py:302-304` (`_startup_account`); `praxis/core/execution_manager.py:219-243` (`active_symbols`); `praxis/infrastructure/binance_adapter.py:958-962` (`_validate_order` cache miss)
-
-`load_filters` runs only when `active_symbols(account_id)` is non-empty at boot, which requires existing orders or positions from the spine. A fresh account with no exposure starts with no filters loaded for the strategies' target symbols. `BinanceAdapter._validate_order` logs a warning and returns without validation when cache misses (`self._filters.get(symbol) is None`). Binance's server-side check is the only remaining safety net.
-
-**When to fix**: Before any deployment where venue rate-limit budget matters, OR alongside MAJOR-007 (filter ValueError orphan) — the no-preload fail-open path is what currently shields fresh accounts from MAJOR-007's orphan trap.
-**Migration**: At boot, walk the manifest's strategy specs to compute the union of intended symbols and call `load_filters(symbols)` before any strategy callback fires. Alternatively, on-demand load inside `_validate_order` on cache miss.
+## TD-045: Symbol filters not loaded for fresh accounts; `_validate_order` fails open — RESOLVED
 
 ---
 

--- a/praxis/launcher.py
+++ b/praxis/launcher.py
@@ -1872,7 +1872,7 @@ class Launcher:
         self._nexus_threads: list[threading.Thread] = []
         self._healthz_runner: web.AppRunner | None = None
         self._outcome_queues: dict[str, queue.Queue[NexusTradeOutcome]] = {}
-        self._outcome_translator = OutcomeTranslator()
+        self._outcome_translator = OutcomeTranslator(fee_rate=_DEFAULT_FEE_RATE)
         self._account_outcome_wiring: dict[str, _AccountOutcomeWiring] = {}
         self._account_outcome_wiring_lock = threading.Lock()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum-praxis"
-version = "0.81.0"
+version = "0.82.0"
 description = "Execution system for Vaquum — Trading sub-system + Account sub-system."
 readme = "README.md"
 authors = [

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -39,7 +39,7 @@ from praxis.infrastructure.venue_adapter import (
     VenueOrder,
     VenueTrade,
 )
-from praxis.launcher import InstanceConfig, Launcher
+from praxis.launcher import _DEFAULT_FEE_RATE, InstanceConfig, Launcher
 from praxis.trading_config import TradingConfig
 
 
@@ -577,3 +577,35 @@ class TestLauncherLifecycle:
         finally:
             loop.call_soon_threadsafe(loop.stop)
             loop_thread.join(timeout=5)
+
+
+class TestLauncherFeeRateWiring:
+    '''The launcher wires the outcome translator with the venue fee rate.'''
+
+    def test_outcome_translator_uses_default_fee_rate(self, tmp_path: Path) -> None:
+        '''Settled fills carry the venue fee, not the zero-fee default.
+
+        The reservation path already estimates fees at `_DEFAULT_FEE_RATE`;
+        the outcome translator must use the same rate so realized fees
+        flowing to Nexus match the reservation and the venue charge,
+        instead of the translator's testnet-era zero default.
+        '''
+
+        config = TradingConfig(epoch_id=1)
+        inst = InstanceConfig(
+            account_id='test-acc',
+            manifest_path=tmp_path / 'manifest.yaml',
+            strategies_base_path=tmp_path,
+            state_dir=tmp_path,
+        )
+        adapter = cast(VenueAdapter, MockVenueAdapter())
+
+        launcher = Launcher(
+            trading_config=config,
+            instances=[inst],
+            db_path=tmp_path / 'spine.db',
+            venue_adapter=adapter,
+        )
+
+        assert Decimal('0') < _DEFAULT_FEE_RATE
+        assert launcher._outcome_translator._fee_rate == _DEFAULT_FEE_RATE


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others.

## What does this PR change?

Two related pieces of post-Conduit cleanup:

### Fee accounting (code)

The launcher constructed the outcome bridge as `OutcomeTranslator()` — defaulting `fee_rate` to `0`, a testnet-era assumption ("testnet does not charge real fees"). The current binsim venue charges a flat 0.10% taker fee, so settled-fill `actual_fees` forwarded to Nexus were `0`: the reserved fee buffer was released back on settlement and realized PnL was booked fee-free, drifting the engine's internal capital/PnL books above the true venue balance by the cumulative fee.

Fix: construct `OutcomeTranslator(fee_rate=_DEFAULT_FEE_RATE)` so settlement uses the same 0.10% the reservation path already uses (`order_notional * fee_rate`). For binsim's flat fee this is exact. Resolves TD-030; Nexus's existing `realized_pnl = gross_pnl - actual_fees` then takes effect.

### Technical-debt register cleanup (docs)

Audited every entry against current code and collapsed the no-longer-live ones to heading-only status markers (headings retained so TD numbers are never reused):
- **RESOLVED** (verified absent in source): TD-009 (`_process_abort` reads `Order.filled_qty`/`cumulative_notional`, no spine re-read), TD-020 (`command_strategy_ids` popped on every terminal path), TD-045 (`bootstrap_filter_symbols` loads BTCUSDT filters on fresh boot), TD-030 (this PR).
- **OBSOLETE** (Conduit migration deleted the subject code): TD-019/060/061/062 (`MarketDataPoller`, its test, the synchronous Limen/binancial fetch, the `_aggregate_spot_klines` Limen helper).
- **Reframed** TD-053 around the Conduit serving-manifest / Arrow freshness path that replaced `MarketDataPoller` (the "demote to REDUCE_ONLY on sustained feed staleness" intent still applies). TD-067 left intact (still-valid integration-test gap).
- **Added** TD-095 recording the one known limitation of the fee fix: the translator re-derives fees from a constant rate rather than the venue-reported `FillReceived.fee` — exact for binsim, an approximation on a maker/taker or fee-discount venue.

## Tests

Added `TestLauncherFeeRateWiring` (asserts the launcher wires the translator with a positive `_DEFAULT_FEE_RATE`); behavioural fee math is covered by `test_outcome_translator.py`. `ruff` clean; full suite **1,563 pass / 1 skipped**. Bumps 0.81.0 → 0.82.0.

## Checklist

- [x] I have reviewed full diff in “Files changed”
- [x] I left no unnecessary files in the changes
- [x] I ran `python tests/run.py` locally without errors (where applicable)
- [ ] I updated `/docs` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md (unless only docs or other non-code aspect was changed)
- [x] I updated pyproject.toml (unless only docs or other non-code aspect was changed)
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [ ] I linked issue to auto-close on merge (e.g., “Fixes #123”) when applicable