### PR TITLE
fix: emit TradeClosed only on position close so positions survive restart (v0.83.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1131,3 +1131,14 @@
 ### Remove
 
 - Prune the technical-debt register in [`docs/TechnicalDebt.md`](docs/TechnicalDebt.md): collapse code-verified-resolved (TD-009, TD-020, TD-030, TD-045) and Conduit-obsoleted (TD-019, TD-060, TD-061, TD-062) entries to heading-only status markers, and reframe TD-053 around the Conduit/Arrow feed-staleness path that replaced `MarketDataPoller`
+
+## v0.83.0 on 16th of June, 2026
+
+### Add
+
+- Add `TestTradeClosedPositionSemantics` to [`tests/test_execution_manager.py`](tests/test_execution_manager.py): an entry fill keeps the position and emits no `TradeClosed`; a reducing fill that closes the position emits `TradeClosed` and clears it. Update `test_full_cycle_submit_fill_outcome_shutdown` to assert the entry position survives a `FILLED` outcome (was asserting deletion)
+- Add TD-096 to [`docs/TechnicalDebt.md`](docs/TechnicalDebt.md) recording that close-detection is side-based, not full-close-aware (partial-exit refinement for future scale-out strategies)
+
+### Fix
+
+- Emit `TradeClosed` only when a fill closes the position, not on every terminal filled order. `_build_outcome` and `_build_abort_outcome` now gate `TradeClosed` on [`_closes_position`](praxis/core/execution_manager.py) (a reducing fill — side opposite the open position), so an entry fill no longer emits it. Previously an entry's `TradeClosed` deleted its own position on event replay, so a process restart rebuilt zero open positions and boot reconciliation evicted the live position (orphaning the venue holding). Entry positions now survive a restart, which the Nexus boot reconciliation depends on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1142,3 +1142,7 @@
 ### Fix
 
 - Emit `TradeClosed` only when a fill closes the position, not on every terminal filled order. `_build_outcome` and `_build_abort_outcome` now gate `TradeClosed` on [`_closes_position`](praxis/core/execution_manager.py) (a reducing fill — side opposite the open position), so an entry fill no longer emits it. Previously an entry's `TradeClosed` deleted its own position on event replay, so a process restart rebuilt zero open positions and boot reconciliation evicted the live position (orphaning the venue holding). Entry positions now survive a restart, which the Nexus boot reconciliation depends on
+
+### Update
+
+- Bump the [`vaquum-nexus`](pyproject.toml) pin to v0.64.0 (`5c63468`), which keys boot reconciliation on `pos.trade_id` and preserves + fails closed on a Nexus-only position instead of silently evicting it. The two changes are coupled: this PR keeps Praxis from under-reporting open positions on replay, and the Nexus pin keeps reconciliation from deleting them

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -835,3 +835,16 @@ Option 1 is the minimum-change path if `Ledger.fills` is confirmed never-read in
 
 **When to fix**: Before mainnet, OR when maker orders / fee tiers are in use.
 **Migration**: Thread the venue-reported `fee` (and `fee_asset`) from `FillReceived` through `Order` and the Praxis `TradeOutcome` aggregate into the translator, and emit it verbatim as `actual_fees` instead of re-deriving from `fee_rate`.
+
+---
+
+## TD-096: `TradeClosed` close-detection is side-based, not full-close-aware
+
+**Origin**: Restart durability fix (`TradeClosed` = position-closed semantics)
+**Severity**: Low (current strategies open one position and exit it in full)
+**Module**: `praxis/core/execution_manager.py`
+
+`_closes_position` treats any reducing fill (side opposite the open position) as closing the position — it emits `TradeClosed` and clears the projection. Under the current single-position, full-exit strategy model this is correct. A partial reducing fill would clear the position prematurely. Praxis does not yet carry the Nexus `OrderContext.intended_full_close` intent, so it cannot distinguish a partial reduce from a full close.
+
+**When to fix**: Before partial-exit / scale-out strategies are used.
+**Migration**: Thread `intended_full_close` (and entry/exit intent) from the Nexus `OrderContext` into the Praxis command/intent events, and emit `TradeClosed` only when the position reaches zero/dust after the reducing fill.

--- a/praxis/core/execution_manager.py
+++ b/praxis/core/execution_manager.py
@@ -1517,7 +1517,9 @@ class ExecutionManager:
         self._commands.pop(order.command_id, None)
         self._aborted_commands.pop(order.command_id, None)
 
-        if filled_qty > _ZERO:
+        if filled_qty > _ZERO and self._closes_position(
+            runtime, order.account_id, trade_id, order.side
+        ):
             closed = TradeClosed(
                 account_id=order.account_id,
                 timestamp=ts,
@@ -1702,7 +1704,9 @@ class ExecutionManager:
             self._commands.pop(cmd.command_id, None)
             self._aborted_commands.pop(cmd.command_id, None)
 
-            if filled_qty > _ZERO:
+            if filled_qty > _ZERO and self._closes_position(
+                runtime, cmd.account_id, cmd.trade_id, cmd.side
+            ):
                 closed = TradeClosed(
                     account_id=cmd.account_id,
                     timestamp=ts,
@@ -1726,3 +1730,37 @@ class ExecutionManager:
         await self._dispatch_outcome_with_retry(outcome, source='process_command')
 
         return outcome
+
+    def _closes_position(
+        self,
+        runtime: _AccountRuntime,
+        account_id: str,
+        trade_id: str,
+        side: OrderSide,
+    ) -> bool:
+        '''Whether a terminal fill on `side` closes the trade's position.
+
+        `TradeClosed` must mean "position lifecycle closed", not merely
+        "order terminal". Emitting it for an entry fill is a durability
+        bug: on event replay the position is created from the entry
+        `FillReceived` and then immediately deleted by the entry's own
+        `TradeClosed`, so a restart rebuilds zero open positions and boot
+        reconciliation evicts the live position. A position closes only
+        on a reducing fill — one whose side is opposite the open
+        position's side. An entry fill (same side as the position it
+        opens) does not close it; a `trade_id` with no live position
+        (already removed by an exact-zero reduction) needs no further
+        `TradeClosed`.
+
+        NOTE: a partial reducing fill also returns True under the current
+        single-position, full-exit strategy model; precise full-close
+        detection for partial exits is tracked as TD-096.
+        '''
+
+        positions = runtime.trading_state.snapshot_positions()
+        pos = positions.get((trade_id, account_id))
+
+        if pos is None:
+            return False
+
+        return side != pos.side

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 ]
 license = { text = "MIT" }
 requires-python = ">=3.12"
-dependencies = ["structlog>=24.1", "orjson>=3.10", "aiosqlite>=0.20", "aiohttp>=3.10", "polars>=1.0", "vaquum-nexus @ git+https://github.com/Vaquum/Nexus@742d85113b2d066f29a4d0325f5d2694daae747c"]
+dependencies = ["structlog>=24.1", "orjson>=3.10", "aiosqlite>=0.20", "aiohttp>=3.10", "polars>=1.0", "vaquum-nexus @ git+https://github.com/Vaquum/Nexus@5c63468e7ee4aed324f598ece58419a704bbe909"]
 
 [project.optional-dependencies]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum-praxis"
-version = "0.82.0"
+version = "0.83.0"
 description = "Execution system for Vaquum — Trading sub-system + Account sub-system."
 readme = "README.md"
 authors = [

--- a/tests/test_execution_manager.py
+++ b/tests/test_execution_manager.py
@@ -2425,3 +2425,55 @@ class TestTradeClosedPositionSemantics:
 
         positions = mgr.pull_positions(_ACCT)
         assert (_TRADE, _ACCT) not in positions
+
+    @pytest.mark.asyncio
+    async def test_exact_full_exit_clears_position_without_trade_closed(
+        self,
+        mgr: ExecutionManager,
+        spine: EventSpine,
+        adapter: AsyncMock,
+    ) -> None:
+        adapter.submit_order.side_effect = [
+            SubmitResult(
+                venue_order_id='v-entry',
+                status=OrderStatus.FILLED,
+                immediate_fills=(
+                    ImmediateFill(
+                        venue_trade_id='t-entry',
+                        qty=Decimal('1'),
+                        price=Decimal('50000'),
+                        fee=Decimal('0.001'),
+                        fee_asset='BTC',
+                        is_maker=False,
+                    ),
+                ),
+            ),
+            SubmitResult(
+                venue_order_id='v-exit',
+                status=OrderStatus.FILLED,
+                immediate_fills=(
+                    ImmediateFill(
+                        venue_trade_id='t-exit',
+                        qty=Decimal('1'),
+                        price=Decimal('51000'),
+                        fee=Decimal('0.001'),
+                        fee_asset='BTC',
+                        is_maker=False,
+                    ),
+                ),
+            ),
+        ]
+        mgr.register_account(_ACCT)
+        await mgr.submit_command(**_CMD_KWARGS)
+        await asyncio.sleep(0.3)
+
+        exit_kwargs = {**_CMD_KWARGS, 'side': OrderSide.SELL, 'qty': Decimal('1')}
+        await mgr.submit_command(**exit_kwargs)
+        await asyncio.sleep(0.3)
+
+        events = await spine.read(_EPOCH, after_seq=0)
+        types = [type(e).__name__ for _, e in events]
+        assert 'TradeClosed' not in types
+
+        positions = mgr.pull_positions(_ACCT)
+        assert (_TRADE, _ACCT) not in positions

--- a/tests/test_execution_manager.py
+++ b/tests/test_execution_manager.py
@@ -473,7 +473,6 @@ class TestProcessCommand:
             'OrderSubmitIntent',
             'OrderSubmitted',
             'FillReceived',
-            'TradeClosed',
             'TradeOutcomeProduced',
         ]
 
@@ -613,7 +612,6 @@ class TestProcessCommand:
             'FillReceived',
             'FillReceived',
             'FillReceived',
-            'TradeClosed',
             'TradeOutcomeProduced',
         ]
 
@@ -657,7 +655,6 @@ class TestProcessCommand:
             'OrderSubmitIntent',
             'OrderSubmitted',
             'FillReceived',
-            'TradeClosed',
             'TradeOutcomeProduced',
         ]
 
@@ -1354,7 +1351,6 @@ class TestProcessAbort:
             'FillReceived',
             'TradeOutcomeProduced',
             'OrderCanceled',
-            'TradeClosed',
             'TradeOutcomeProduced',
         ]
 
@@ -2335,3 +2331,97 @@ class TestSubmitCommandRealChain:
             assert events == []
         finally:
             await em.unregister_account(_ACCT)
+
+
+class TestTradeClosedPositionSemantics:
+    '''TradeClosed marks position close, not order terminal.
+
+    Regression guard for the restart durability bug: an entry fill that
+    emitted TradeClosed deleted its own position on replay, so a restart
+    rebuilt zero positions and boot reconciliation evicted the live one.
+    '''
+
+    @pytest.mark.asyncio
+    async def test_entry_fill_keeps_position_and_emits_no_trade_closed(
+        self,
+        mgr: ExecutionManager,
+        spine: EventSpine,
+        adapter: AsyncMock,
+    ) -> None:
+        adapter.submit_order.return_value = SubmitResult(
+            venue_order_id='v-entry',
+            status=OrderStatus.FILLED,
+            immediate_fills=(
+                ImmediateFill(
+                    venue_trade_id='t-entry',
+                    qty=Decimal('1'),
+                    price=Decimal('50000'),
+                    fee=Decimal('0.001'),
+                    fee_asset='BTC',
+                    is_maker=False,
+                ),
+            ),
+        )
+        mgr.register_account(_ACCT)
+        await mgr.submit_command(**_CMD_KWARGS)
+        await asyncio.sleep(0.3)
+
+        events = await spine.read(_EPOCH, after_seq=0)
+        types = [type(e).__name__ for _, e in events]
+        assert 'TradeClosed' not in types
+
+        positions = mgr.pull_positions(_ACCT)
+        assert (_TRADE, _ACCT) in positions
+        assert positions[(_TRADE, _ACCT)].qty == Decimal('1')
+
+    @pytest.mark.asyncio
+    async def test_closing_fill_emits_trade_closed_and_clears_position(
+        self,
+        mgr: ExecutionManager,
+        spine: EventSpine,
+        adapter: AsyncMock,
+    ) -> None:
+        adapter.submit_order.side_effect = [
+            SubmitResult(
+                venue_order_id='v-entry',
+                status=OrderStatus.FILLED,
+                immediate_fills=(
+                    ImmediateFill(
+                        venue_trade_id='t-entry',
+                        qty=Decimal('1'),
+                        price=Decimal('50000'),
+                        fee=Decimal('0.001'),
+                        fee_asset='BTC',
+                        is_maker=False,
+                    ),
+                ),
+            ),
+            SubmitResult(
+                venue_order_id='v-exit',
+                status=OrderStatus.FILLED,
+                immediate_fills=(
+                    ImmediateFill(
+                        venue_trade_id='t-exit',
+                        qty=Decimal('0.99999'),
+                        price=Decimal('51000'),
+                        fee=Decimal('0.001'),
+                        fee_asset='BTC',
+                        is_maker=False,
+                    ),
+                ),
+            ),
+        ]
+        mgr.register_account(_ACCT)
+        await mgr.submit_command(**_CMD_KWARGS)
+        await asyncio.sleep(0.3)
+
+        exit_kwargs = {**_CMD_KWARGS, 'side': OrderSide.SELL, 'qty': Decimal('0.99999')}
+        await mgr.submit_command(**exit_kwargs)
+        await asyncio.sleep(0.3)
+
+        events = await spine.read(_EPOCH, after_seq=0)
+        types = [type(e).__name__ for _, e in events]
+        assert 'TradeClosed' in types
+
+        positions = mgr.pull_positions(_ACCT)
+        assert (_TRADE, _ACCT) not in positions

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -507,9 +507,12 @@ class TestLauncherLifecycle:
         )
 
         positions = launcher._trading.pull_positions('test-acc')
-        assert positions == {}, (
-            f'position should be deleted after FILLED outcome → TradeClosed; got {positions}'
+        assert ('trade-1', 'test-acc') in positions, (
+            f'entry position must survive a FILLED outcome — an entry fill '
+            f'no longer emits TradeClosed, so the position stays tracked and '
+            f'is recoverable across a restart; got {positions}'
         )
+        assert positions[('trade-1', 'test-acc')].qty == Decimal('1')
 
         stop_future = asyncio.run_coroutine_threadsafe(launcher._trading.stop(), launcher._loop)
         stop_future.result(timeout=10)


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others.

## What does this PR change?

Fixes a restart durability bug: a process restart silently dropped open positions, leaving the venue holding orphaned and the books flat.

### Root cause

`_build_outcome` (and `_build_abort_outcome`) appended a `TradeClosed` event for **any** terminal order with `filled_qty > 0` — including an **entry** fill. `TradingState` applies `TradeClosed` by deleting the position. So on event replay each position was created from its entry `FillReceived` and then immediately deleted by the entry's own `TradeClosed`; a restart rebuilt zero open positions and Nexus boot reconciliation then evicted the live position (orphaning the venue holding). Earlier deploys masked this by resetting the epoch (so Nexus also booted empty).

### Fix

`TradeClosed` now means "position closed", not "order terminal". Both emission sites are gated on the new [`_closes_position`](praxis/core/execution_manager.py) — a reducing fill whose side is opposite the open position's side. An entry fill (same side as the position it opens) no longer emits `TradeClosed`, so positions persist in `TradingState` and survive a restart. Exact-zero exits delete the position via the existing fill path (replay-consistent); dust-residual exits emit `TradeClosed` and pop the residue.

Partial-reducing-fill precision (vs. full-close) is recorded as TD-096 — the current single-position, full-exit strategy model does not exercise it.

## Tests

Added `TestTradeClosedPositionSemantics` (entry fill keeps the position and emits no `TradeClosed`; a reducing fill that closes the position emits it and clears it). Updated the four `execution_manager` event-sequence tests and the launcher `test_full_cycle_submit_fill_outcome_shutdown` that asserted the old entry-side `TradeClosed`/deletion. `ruff` clean, full suite **1,565 pass / 1 skipped**. Bumps 0.82.0 → 0.83.0.

## Checklist

- [x] I have reviewed full diff in “Files changed”
- [x] I left no unnecessary files in the changes
- [x] I ran `python tests/run.py` locally without errors (where applicable)
- [ ] I updated `/docs` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md (unless only docs or other non-code aspect was changed)
- [x] I updated pyproject.toml (unless only docs or other non-code aspect was changed)
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [ ] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [ ] I linked issue to auto-close on merge (e.g., “Fixes #123”) when applicable