### PR TITLE
chore: bump vaquum-nexus to v0.65.0 (capital sub-ULP residue fix) (v0.83.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1146,3 +1146,9 @@
 ### Update
 
 - Bump the [`vaquum-nexus`](pyproject.toml) pin to v0.64.0 (`5c63468`), which keys boot reconciliation on `pos.trade_id` and preserves + fails closed on a Nexus-only position instead of silently evicting it. The two changes are coupled: this PR keeps Praxis from under-reporting open positions on replay, and the Nexus pin keeps reconciliation from deleting them
+
+## v0.83.1 on 16th of June, 2026
+
+### Update
+
+- Bump the [`vaquum-nexus`](pyproject.toml) pin to v0.65.0 (`f0dec50`): snaps sub-ULP Decimal residues in the capital aggregates to zero so a restart cannot brick recovery on a persisted `-1E-27` `working_order_notional`. Required alongside the fee-aware settlement (v0.82.0), which made the residue non-zero; full suite passes against the upgraded pin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum-praxis"
-version = "0.83.0"
+version = "0.83.1"
 description = "Execution system for Vaquum — Trading sub-system + Account sub-system."
 readme = "README.md"
 authors = [
@@ -12,7 +12,7 @@ authors = [
 ]
 license = { text = "MIT" }
 requires-python = ">=3.12"
-dependencies = ["structlog>=24.1", "orjson>=3.10", "aiosqlite>=0.20", "aiohttp>=3.10", "polars>=1.0", "vaquum-nexus @ git+https://github.com/Vaquum/Nexus@5c63468e7ee4aed324f598ece58419a704bbe909"]
+dependencies = ["structlog>=24.1", "orjson>=3.10", "aiosqlite>=0.20", "aiohttp>=3.10", "polars>=1.0", "vaquum-nexus @ git+https://github.com/Vaquum/Nexus@f0dec506643114be003a4164c14acbb8628f2ea5"]
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others.

## What does this PR change?

Bumps the `vaquum-nexus` pin from v0.64.0 (`5c63468`) to **v0.65.0** (`f0dec50`).

Nexus v0.65.0 snaps sub-ULP Decimal residues in the capital aggregates to zero, so a process restart cannot brick recovery on a persisted `working_order_notional = -1E-27`. That residue is latent until the fee-aware settlement (Praxis v0.82.0) makes `actual_fees` non-zero, so the two ship together: Praxis must run the residue-tolerant Nexus to be restart-safe after fee-enabled trading.

No Praxis source change — pin + version + changelog only.

## Tests

No Praxis code changed. Reinstalled the new pin and ran the full suite against Nexus v0.65.0: **1,566 pass / 1 skipped**, `ruff` clean. Bumps 0.83.0 → 0.83.1.

## Checklist

- [x] I have reviewed full diff in “Files changed”
- [x] I left no unnecessary files in the changes
- [x] I ran `python tests/run.py` locally without errors (where applicable)
- [ ] I updated `/docs` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md (unless only docs or other non-code aspect was changed)
- [x] I updated pyproject.toml (unless only docs or other non-code aspect was changed)
- [ ] I added and/or updated tests (if behavior changed or new code paths added)
- [ ] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [ ] I linked issue to auto-close on merge (e.g., “Fixes #123”) when applicable