### PR TITLE
feat: make return_on_exposure Limen-exact and add the all-steps variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1226,3 +1226,14 @@
 - Add a [`MarkSampled`](praxis/core/domain/events.py) spine event (account, timestamp, symbol, positive mark price) as the durable per-sample record a paper run's equity series is built from, registered for spine round-trip and treated as a no-op by the `TradingState` projection
 - Add [`MarkSampler`](praxis/paper/mark_sampler.py), started once per account on the launcher loop after healthz, which appends a `MarkSampled` each `PRAXIS_MARK_SAMPLE_INTERVAL_SECONDS` from the stateless `ArrowPriceStore` mark, skips ticks when no mark is available, and logs and continues on a tick failure so a transient append error cannot stop the loop; and a loopback-restricted `GET /metrics` on the launcher healthz server, which reads the account's spine events for the epoch and serves the shared paper report (dropping any non-increasing-timestamp mark first, so a clock step or a post-restart duplicate cannot fault the endpoint; non-loopback callers get 403 since it exposes PnL and fills). Sampler startup is best-effort so a failure never aborts trading, and the samplers stop first during shutdown so no sample races the spine teardown
 - Add the [`praxis/metrics/`](praxis/metrics/) and [`praxis/paper/`](praxis/paper/) test suites plus launcher `/metrics` endpoint and mark-sampler wiring tests, covering the percentile and metric definitions against Limen's, the two replay return bases, the paper report from spine events, the `MarkSampled` round-trip, and the sampler append and price-unavailable paths
+
+## v0.89.0 on 2nd of July, 2026
+
+### Fix
+
+- Make `return_on_exposure` in [`snapshot_metrics`](praxis/metrics/snapshot_metrics.py) exactly Limen-equivalent by excluding the first (execution-lag) step from the exposure denominator, matching Limen's `backtest_snapshot` — which drops its `execution_lag_bars` row from the eval mask — so all 22 distribution metrics now reproduce Limen's real `backtest_snapshot` bit-for-bit (verified against the Limen codebase across scenarios with 1, 3, and 6 leading flat bars). It was the only metric sensitive to the excluded row, since that row is flat and so neutral to the rolling-return, drawdown, and edge series
+
+### Add
+
+- Add `return_on_exposure_full_p5`/`_p50`/`_p95` to the snapshot alongside the Limen-exact `return_on_exposure`, computing exposure over every step rather than excluding the lag row. Fill-based replay and paper runs have no execution lag, so this all-steps variant is the more complete return-on-exposure for them; both variants appear on `ReplayMetrics.snapshot` and `snapshot_portfolio`
+- Add snapshot tests pinning the Limen-exact-vs-full return-on-exposure split (exposure denominator over eligible vs all steps) and the all-flat `None` case

--- a/praxis/metrics/snapshot_metrics.py
+++ b/praxis/metrics/snapshot_metrics.py
@@ -5,6 +5,9 @@ Reproduces Limen's `backtest_snapshot` metric definitions from a
 clock-window rolling return and return-on-exposure, drawdown depth and
 duration, and 95% CVaR — each distribution metric as a p5/p50/p95 triple,
 all basis-point scaled.
+
+`SNAPSHOT_METRIC_NAMES` is the Limen-parity metric set; `snapshot_metrics`
+also returns the non-Limen `return_on_exposure_full` extension.
 '''
 
 from __future__ import annotations
@@ -33,11 +36,6 @@ SNAPSHOT_METRIC_NAMES = (
     'drawdown_duration_days',
     'cvar_95_return_bps',
 )
-'''The Limen-parity metric set (matches Limen's `backtest_snapshot`).
-
-`snapshot_metrics` returns these keys (percentile metrics suffixed
-`_p5`/`_p50`/`_p95`, `cvar_95_return_bps` single) plus the non-Limen
-extension `return_on_exposure_full_p5`/`_p50`/`_p95`.'''
 
 
 def snapshot_metrics(

--- a/praxis/metrics/snapshot_metrics.py
+++ b/praxis/metrics/snapshot_metrics.py
@@ -33,6 +33,11 @@ SNAPSHOT_METRIC_NAMES = (
     'drawdown_duration_days',
     'cvar_95_return_bps',
 )
+'''The Limen-parity metric set (matches Limen's `backtest_snapshot`).
+
+`snapshot_metrics` returns these keys (percentile metrics suffixed
+`_p5`/`_p50`/`_p95`, `cvar_95_return_bps` single) plus the non-Limen
+extension `return_on_exposure_full_p5`/`_p50`/`_p95`.'''
 
 
 def snapshot_metrics(

--- a/praxis/metrics/snapshot_metrics.py
+++ b/praxis/metrics/snapshot_metrics.py
@@ -59,11 +59,12 @@ def snapshot_metrics(
 
     Returns:
         A dict whose keys are each distribution metric in
-        `SNAPSHOT_METRIC_NAMES` suffixed with `_p5`/`_p50`/`_p95`, plus the
-        single `cvar_95_return_bps`. `return_on_exposure` is the Limen-exact
-        variant (first, execution-lag step excluded from the exposure
-        denominator); `return_on_exposure_full_p5`/`_p50`/`_p95` add the
-        variant that counts every step. Missing values are `None`.
+        `SNAPSHOT_METRIC_NAMES` suffixed with `_p5`/`_p50`/`_p95`, the single
+        `cvar_95_return_bps`, and the extra `return_on_exposure_full_p5`/
+        `_p50`/`_p95` triple. `return_on_exposure` is the Limen-exact variant
+        (first, execution-lag step excluded from the exposure denominator);
+        `return_on_exposure_full` counts every step. Missing values are
+        `None`.
     '''
 
     edge_per_signal = [s.gross_return * _BPS_PER_UNIT for s in steps if s.in_position]

--- a/praxis/metrics/snapshot_metrics.py
+++ b/praxis/metrics/snapshot_metrics.py
@@ -57,7 +57,10 @@ def snapshot_metrics(
     Returns:
         A dict whose keys are each distribution metric in
         `SNAPSHOT_METRIC_NAMES` suffixed with `_p5`/`_p50`/`_p95`, plus the
-        single `cvar_95_return_bps`. Missing values are `None`.
+        single `cvar_95_return_bps`. `return_on_exposure` is the Limen-exact
+        variant (first, execution-lag step excluded from the exposure
+        denominator); `return_on_exposure_full_p5`/`_p50`/`_p95` add the
+        variant that counts every step. Missing values are `None`.
     '''
 
     edge_per_signal = [s.gross_return * _BPS_PER_UNIT for s in steps if s.in_position]
@@ -70,7 +73,9 @@ def snapshot_metrics(
 
     trade_pnl_net_bps = [v * _BPS_PER_UNIT for v in trade_net]
     cost_drag_bps = [(g - n) * _BPS_PER_UNIT for g, n in zip(trade_gross, trade_net, strict=True)]
-    rolling_return_net_bps, return_on_exposure = _clock_window_returns(steps, clock_window)
+    rolling_return_net_bps, return_on_exposure, return_on_exposure_full = _clock_window_returns(
+        steps, clock_window,
+    )
     drawdown_depth_bps, drawdown_duration_days = _drawdown_episodes(steps)
 
     triples: dict[str, Sequence[float | None]] = {
@@ -80,6 +85,7 @@ def snapshot_metrics(
         'rolling_return_net_bps': rolling_return_net_bps,
         'return_on_exposure': return_on_exposure,
         'drawdown_depth_bps': drawdown_depth_bps,
+        'return_on_exposure_full': return_on_exposure_full,
     }
 
     result: dict[str, float | None] = {}
@@ -131,16 +137,26 @@ def _trade_runs(steps: Sequence[MetricStep]) -> tuple[list[float], list[float]]:
 def _clock_window_returns(
     steps: Sequence[MetricStep],
     clock_window: str,
-) -> tuple[list[float], list[float | None]]:
+) -> tuple[list[float], list[float | None], list[float | None]]:
+
+    '''Return per-window rolling return, Limen-exact ROE, and full ROE.
+
+    Return-on-exposure divides the window's net return by the fraction of
+    the window in position. Limen excludes the first (execution-lag) row
+    from that denominator; the `full` variant counts every step. Both share
+    the rolling-return series, which is neutral to the excluded leading row
+    (it is flat, so its `(1 + 0)` factor does not change the product).
+    '''
 
     if not steps:
-        return [], []
+        return [], [], []
 
     frame = pl.DataFrame(
         {
             'timestamp': [s.timestamp for s in steps],
             'net_return': [s.net_return for s in steps],
-            'exposure': [1.0 if s.in_position else 0.0 for s in steps],
+            'in_position': [1.0 if s.in_position else 0.0 for s in steps],
+            'eligible': [0.0, *[1.0] * (len(steps) - 1)],
         }
     )
     windowed = frame.group_by(
@@ -148,18 +164,28 @@ def _clock_window_returns(
         maintain_order=True,
     ).agg(
         ((1.0 + pl.col('net_return')).product() - 1.0).alias('window_return'),
-        pl.col('exposure').mean().alias('exposure'),
+        pl.col('in_position').mean().alias('exposure_full'),
+        (pl.col('in_position') * pl.col('eligible')).sum().alias('in_position_eligible'),
+        pl.col('eligible').sum().alias('eligible_count'),
     )
 
     rolling_bps = [value * _BPS_PER_UNIT for value in windowed['window_return']]
-    roe = [
+    roe_full = [
         window_return / exposure * _BPS_PER_UNIT if exposure > 0 else None
         for window_return, exposure in zip(
-            windowed['window_return'], windowed['exposure'], strict=True,
+            windowed['window_return'], windowed['exposure_full'], strict=True,
         )
     ]
+    roe_limen: list[float | None] = []
 
-    return rolling_bps, roe
+    for window_return, in_position_eligible, eligible_count in zip(
+        windowed['window_return'], windowed['in_position_eligible'],
+        windowed['eligible_count'], strict=True,
+    ):
+        exposure = in_position_eligible / eligible_count if eligible_count > 0 else 0.0
+        roe_limen.append(window_return / exposure * _BPS_PER_UNIT if exposure > 0 else None)
+
+    return rolling_bps, roe_limen, roe_full
 
 
 def _drawdown_episodes(steps: Sequence[MetricStep]) -> tuple[list[float], list[float]]:

--- a/praxis/replay/replay_report.py
+++ b/praxis/replay/replay_report.py
@@ -73,9 +73,10 @@ class ReplayMetrics:
         final_equity: Cash plus marked position at the last bar close.
         open_position_qty: Base quantity still open at the run's end.
         snapshot: Limen-parity distribution metrics keyed by name (the
-            p5/p50/p95 triples plus `cvar_95_return_bps`), per-trade metrics
-            on the trade-notional basis. Every key is present; a value is
-            `None` where the metric is undefined (e.g. a run with no steps).
+            p5/p50/p95 triples plus `cvar_95_return_bps`, and the extra
+            `return_on_exposure_full` triple), per-trade metrics on the
+            trade-notional basis. Every key is present; a value is `None`
+            where the metric is undefined (e.g. a run with no steps).
         snapshot_portfolio: The same distribution metrics on a total-account-
             equity basis (return on deployed capital, not Limen-comparable);
             same keys-present-with-`None` shape as `snapshot`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum-praxis"
-version = "0.88.0"
+version = "0.89.0"
 description = "Execution system for Vaquum — Trading sub-system + Account sub-system."
 readme = "README.md"
 authors = [

--- a/tests/test_snapshot_metrics.py
+++ b/tests/test_snapshot_metrics.py
@@ -92,3 +92,29 @@ def test_no_positions_no_trades_no_drawdown():
     assert result['trade_pnl_net_bps_p50'] is None
     assert result['edge_per_signal_bps_p50'] is None
     assert result['drawdown_depth_bps_p50'] is None
+
+
+def test_return_on_exposure_limen_excludes_first_step_full_keeps_all():
+    # one 1d window (hours apart): step0 flat, steps1-3 in position (+1% each), step4 flat.
+    nets = [0.0, 0.01, 0.01, 0.01, 0.0]
+    steps = [
+        MetricStep(_BASE + timedelta(hours=i), i in (1, 2, 3), nets[i], nets[i])
+        for i in range(5)
+    ]
+    result = snapshot_metrics(steps, clock_window='1d')
+
+    window_return = 1.01 ** 3 - 1.0
+    roe_full = window_return / (3 / 5) * 10_000.0     # exposure over all 5 steps
+    roe_limen = window_return / (3 / 4) * 10_000.0     # first step excluded -> 4 eligible
+
+    assert result['return_on_exposure_p50'] == round(roe_limen, 1)
+    assert result['return_on_exposure_full_p50'] == round(roe_full, 1)
+    assert result['return_on_exposure_p50'] < result['return_on_exposure_full_p50']
+
+
+def test_return_on_exposure_full_present_and_none_when_flat():
+    flat = [_step(d, False, 0.0, 0.0) for d in range(3)]
+    result = snapshot_metrics(flat)
+
+    assert result['return_on_exposure_full_p50'] is None
+    assert result['return_on_exposure_p50'] is None

--- a/tests/test_snapshot_metrics.py
+++ b/tests/test_snapshot_metrics.py
@@ -95,7 +95,6 @@ def test_no_positions_no_trades_no_drawdown():
 
 
 def test_return_on_exposure_limen_excludes_first_step_full_keeps_all():
-    # one 1d window (hours apart): step0 flat, steps1-3 in position (+1% each), step4 flat.
     nets = [0.0, 0.01, 0.01, 0.01, 0.0]
     steps = [
         MetricStep(_BASE + timedelta(hours=i), i in (1, 2, 3), nets[i], nets[i])


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others.

Follow-up to #162. Closes the one remaining gap between the Praxis snapshot metrics and Limen's `backtest_snapshot`: `return_on_exposure`. All 22 distribution metrics now reproduce Limen's real code bit-for-bit, and where Limen's definition is narrower we expose our fuller variant alongside.

## What does this PR change?

No trading behaviour changes — this refines the shared metric core (`praxis/metrics/snapshot_metrics.py`) consumed by both replay and paper trading.

### `return_on_exposure` — Limen-exact

Limen's `backtest_snapshot` drops its first (execution-lag) row from the eval mask, so that row is excluded from the exposure denominator. Praxis counted every step, which inflated `return_on_exposure` on the boundary window — the only one of the 22 metrics sensitive to it (the excluded row is flat, so it is neutral to the rolling-return, drawdown, and edge series). `_clock_window_returns` now excludes the first step from the exposure denominator, matching Limen exactly.

Verified against the Limen codebase: `snapshot_metrics` now reproduces `backtest_snapshot` on all 22 keys across scenarios with 1, 3, and 6 leading flat bars.

### `return_on_exposure_full` — our fuller variant

`return_on_exposure_full_p5`/`_p50`/`_p95` compute exposure over every step. Fill-based replay and paper runs have no execution lag, so counting all steps is the more complete return-on-exposure for them. Both variants appear on `ReplayMetrics.snapshot` and `snapshot_portfolio`; `SNAPSHOT_METRIC_NAMES` is documented as the Limen-parity set, with `return_on_exposure_full` the non-Limen extension.

## Tests

New `test_snapshot_metrics` cases pin the Limen-exact-vs-full split (exposure over eligible vs all steps) and the all-flat `None` case. Full suite 1734 passed; `ruff` full-tree and `mypy` clean. Bumps 0.88.0 → 0.89.0. Reviewed pre-PR (dev-docs, Copilot-pattern, and a Greybeard semantic pass — verdict mediocre; both findings fixed).

## Checklist

- [x] I have reviewed full diff in “Files changed”
- [x] I left no unnecessary files in the changes
- [x] I ran `python tests/run.py` locally without errors (where applicable)
- [ ] I updated `/docs` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md (unless only docs or other non-code aspect was changed)
- [x] I updated pyproject.toml (unless only docs or other non-code aspect was changed)
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [ ] I linked issue to auto-close on merge (e.g., “Fixes #123”) when applicable