### PR TITLE
feat: Account sub-system — double-entry ledger, registration, fees, funds, read interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1256,3 +1256,18 @@
 - Make `return_on_exposure` in [`snapshot_metrics`](praxis/metrics/snapshot_metrics.py) internally consistent by computing its numerator and denominator over the same steps, dropping the execution-lag eligible/first-step split; `snapshot_metrics` now serves the portfolio basis only
 - Validate a timezone-aware timestamp and finite returns on [`MetricStep`](praxis/metrics/metric_step.py); cancel the [`MarkSampler`](praxis/paper/mark_sampler.py) task on stop so a stuck spine append cannot block shutdown, and guard the sampler build against a duplicate start; wrap the launcher `/metrics` read and report build so malformed spine state returns a structured `500` rather than an unhandled error
 - Restate the ledger volume metric as Praxis's actual filled entry notional (`entry_price * qty`) rather than claiming exact parity with Limen's reinvestment-model volume; `expected_value` remains the Limen-parity scalar
+
+## v0.91.0 on 6th of July, 2026
+
+### NOTE
+
+- The Account sub-system is a per-account double-entry ledger — the authoritative books, distinct from Nexus which owns capital and PnL for decisions. [`AccountLedger`](praxis/core/account_ledger.py) is a projection rebuilt by replaying Event Spine events, like `TradingState`; it is a secondary projection, so a booking failure is logged and never propagated into the trading path
+- [`JournalEntry`](praxis/core/domain/journal_entry.py) moves from the trade-specific `trade_id`/`command_id` fields to generic `source_event_type`/`source_event_id`, since each entry derives from exactly one spine event; `CostBasisMethod` moves to the shared [`enums`](praxis/core/domain/enums.py) module
+
+### Add
+
+- Add a [`RegisterAccount`](praxis/core/domain/events.py) spine event that fixes each account's immutable `cost_basis_method` (FIFO default, validated). The ledger starts unregistered and is strict: a `FillReceived` or `TradeClosed` before registration is rejected, and re-registration raises
+- Wire [`AccountLedger.apply`](praxis/core/execution_manager.py) into the per-account spine-append path via a single projection helper, at replay and the live fill and trade-closed append sites. A genuinely new account durably emits `RegisterAccount` at startup; pre-feature spine history that carries no `RegisterAccount` is registered in memory with the FIFO default at replay and never written back
+- Add base-asset fee handling: a `BTC` fee on a buy is valued at the fill price, credits `Crypto:BTC` rather than `Cash:USDT`, and reduces the cost-basis lot to the net quantity received, so the ledger's base inventory and cost basis match the venue balance. Quote-asset (`USDT`) fees are unchanged; any other fee asset raises
+- Add a [`FundTransaction`](praxis/core/domain/events.py) spine event (`amount`, a `FundDirection` of `DEPOSIT` or `WITHDRAWAL`, and a stable `fund_transaction_id`) booking a deposit as `Dr Cash:USDT / Cr Equity:Contributions` and a withdrawal as the reverse; the ledger records an over-withdrawal rather than rejecting it, since enforcement belongs upstream
+- Add balances and per-trade realized-P&L read accessors — `read_balances`/`read_trade_pnls` on [`AccountLedger`](praxis/core/account_ledger.py) and `get_account_balances`/`get_account_trade_pnls` on [`ExecutionManager`](praxis/core/execution_manager.py) — returning detached copies so a caller cannot mutate the projection

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -936,3 +936,25 @@ A strategy's `on_startup` actions are drained inside `_build_nexus_runtime` (via
 
 **When to fix**: before the endpoint is polled frequently or a paper epoch runs long enough for the read to dominate response time.
 **Migration**: read only the account's events (a spine query filtered by `account_id`), and/or cache the built report between samples and invalidate on new fills.
+
+## TD-107: Account-ledger projection failures are swallowed
+
+**Origin**: Account sub-system branch (Greybeard pre-PR review)
+**Severity**: Low (the ledger is a secondary projection; the Event Spine remains the durable record)
+**Module**: `praxis/core/execution_manager.py` (`_project_to_ledger`)
+
+`_project_to_ledger` wraps `AccountLedger.apply` in a broad `except` that logs and never propagates, so a booking failure cannot break the trading path. The trade-off is that the "authoritative books" can silently and permanently stop booking — e.g. if a fill reaches an unregistered ledger, every subsequent fill for that account is swallowed and only a log line records it. Nothing surfaces the drift to an operator.
+
+**When to fix**: before the ledger balances back any user-facing reporting or reconciliation that must be trusted without cross-checking the spine.
+**Migration**: add a metric/alert on ledger projection failures (count per account), or a periodic reconciliation of the ledger against a spine replay, so silent drift is detected rather than only logged.
+
+## TD-108: FundTransaction has no spine-level idempotency
+
+**Origin**: Account sub-system branch (Greybeard / Copilot pre-PR review)
+**Severity**: Low (replay applies each spine event once; the risk is a duplicate append, not replay)
+**Module**: `praxis/infrastructure/event_spine.py`; `praxis/core/account_ledger.py` (`_on_fund_transaction`)
+
+`FundTransaction` carries a stable `fund_transaction_id`, but the spine only deduplicates `FillReceived` (on `venue_trade_id`). A duplicate `FundTransaction` append would double-book capital against `Equity:Contributions` with nothing to stop it; the id is stored for a future dedup that does not exist yet.
+
+**When to fix**: before a fund-transaction producer that can retry appends (e.g. a deposit API or Nexus-driven top-up) is wired in.
+**Migration**: extend the spine dedup to key `FundTransaction` on `fund_transaction_id` (as `FillReceived` does on `venue_trade_id`), so a duplicate append is a no-op.

--- a/praxis/core/account_ledger.py
+++ b/praxis/core/account_ledger.py
@@ -1,0 +1,207 @@
+'''Double-entry ledger projection for the Praxis Account sub-system.
+
+`AccountLedger` is rebuilt by replaying Event Spine events. Each fill
+posts a balanced `JournalEntry` and updates account balances; realized
+P&L on a sell is computed against the position's cost basis. Like
+`TradingState`, this is a derived view of the event log, not an
+independent store.
+
+Cost basis is chosen per account — FIFO or weighted-average (AVERAGE).
+Fees are expensed to `Expense:Fees`; the base asset is carried at trade
+price (fees are not capitalised), so realized P&L is the proceeds less the
+lot cost (FIFO or average) and fees stand alone.
+'''
+
+from __future__ import annotations
+
+import logging
+import threading
+from collections import deque
+from dataclasses import dataclass
+from decimal import Decimal
+from enum import Enum
+
+from praxis.core.domain.chart_of_accounts import Account, is_debit_normal
+from praxis.core.domain.enums import OrderSide
+from praxis.core.domain.events import Event, FillReceived, TradeClosed
+from praxis.core.domain.journal_entry import JournalEntry, JournalLine
+
+__all__ = ['AccountLedger', 'CostBasisMethod']
+
+_log = logging.getLogger(__name__)
+
+_ZERO = Decimal(0)
+_QUOTE_ASSET = 'USDT'
+
+
+class CostBasisMethod(Enum):
+
+    '''Cost-basis method for realizing P&L on a sell.'''
+
+    FIFO = 'FIFO'
+    AVERAGE = 'AVERAGE'
+
+
+@dataclass
+class _Lot:
+
+    qty: Decimal
+    unit_cost: Decimal
+
+
+class AccountLedger:
+
+    '''In-memory double-entry ledger projection for one account.
+
+    Args:
+        account_id: Account this ledger belongs to.
+        cost_basis_method: Method for realizing P&L on a sell — `FIFO` or
+            `AVERAGE` (weighted average). Set immutably per account.
+    '''
+
+    def __init__(
+        self,
+        account_id: str,
+        cost_basis_method: CostBasisMethod = CostBasisMethod.FIFO,
+    ) -> None:
+
+        if not account_id:
+            msg = 'AccountLedger.account_id must be a non-empty string'
+            raise ValueError(msg)
+
+        if not isinstance(cost_basis_method, CostBasisMethod):
+            msg = f'unsupported cost_basis_method: {cost_basis_method}'
+            raise ValueError(msg)
+
+        self.account_id = account_id
+        self.cost_basis_method = cost_basis_method
+        self.balances: dict[Account, Decimal] = dict.fromkeys(Account, _ZERO)
+        self.journal: list[JournalEntry] = []
+        self._lots: dict[str, deque[_Lot]] = {}
+        self._lock = threading.Lock()
+
+    def apply(self, event: Event) -> None:
+
+        '''Apply a single event, posting a journal entry where it books.
+
+        Args:
+            event: Domain event to project.
+        '''
+
+        if isinstance(event, FillReceived):
+            self._on_fill_received(event)
+
+        elif isinstance(event, TradeClosed):
+            return
+
+    def _on_fill_received(self, event: FillReceived) -> None:
+
+        if event.fee_asset != _QUOTE_ASSET:
+            msg = f'fee_asset {event.fee_asset!r} not yet supported (only {_QUOTE_ASSET})'
+            raise NotImplementedError(msg)
+
+        if event.side is OrderSide.BUY:
+            self._post(self._buy_entry(event))
+
+        else:
+            self._post(self._sell_entry(event))
+
+    def _buy_entry(self, event: FillReceived) -> JournalEntry:
+
+        notional = event.qty * event.price
+        lines = [
+            JournalLine(Account.CRYPTO_BTC, notional, _ZERO),
+            JournalLine(Account.CASH_USDT, _ZERO, notional),
+        ]
+        lines.extend(self._fee_lines(event.fee))
+        self._add_lot(event.trade_id, event.qty, event.price)
+
+        return self._entry(event, 'buy fill', lines)
+
+    def _add_lot(self, trade_id: str, qty: Decimal, price: Decimal) -> None:
+
+        lots = self._lots.setdefault(trade_id, deque())
+
+        if self.cost_basis_method is CostBasisMethod.AVERAGE and lots:
+            existing = lots[0]
+            total_qty = existing.qty + qty
+            existing.unit_cost = (existing.qty * existing.unit_cost + qty * price) / total_qty
+            existing.qty = total_qty
+
+            return
+
+        lots.append(_Lot(qty, price))
+
+    def _sell_entry(self, event: FillReceived) -> JournalEntry:
+
+        proceeds = event.qty * event.price
+        cost = self._consume_lots(event.trade_id, event.qty)
+        realized = proceeds - cost
+        lines = [
+            JournalLine(Account.CASH_USDT, proceeds, _ZERO),
+            JournalLine(Account.CRYPTO_BTC, _ZERO, cost),
+        ]
+
+        if realized > _ZERO:
+            lines.append(JournalLine(Account.REALIZED_PNL, _ZERO, realized))
+
+        elif realized < _ZERO:
+            lines.append(JournalLine(Account.REALIZED_PNL, -realized, _ZERO))
+
+        lines.extend(self._fee_lines(event.fee))
+
+        return self._entry(event, 'sell fill', lines)
+
+    def _consume_lots(self, trade_id: str, qty: Decimal) -> Decimal:
+
+        lots = self._lots.get(trade_id)
+        remaining = qty
+        cost = _ZERO
+
+        while remaining > _ZERO and lots:
+
+            lot = lots[0]
+            taken = min(remaining, lot.qty)
+            cost += taken * lot.unit_cost
+            lot.qty -= taken
+            remaining -= taken
+
+            if lot.qty <= _ZERO:
+                lots.popleft()
+
+        if remaining > _ZERO:
+            msg = f'sell qty exceeds open lots for trade_id={trade_id!r} by {remaining}'
+            raise ValueError(msg)
+
+        return cost
+
+    @staticmethod
+    def _fee_lines(fee: Decimal) -> list[JournalLine]:
+
+        if fee <= _ZERO:
+            return []
+
+        return [
+            JournalLine(Account.FEES, fee, _ZERO),
+            JournalLine(Account.CASH_USDT, _ZERO, fee),
+        ]
+
+    @staticmethod
+    def _entry(event: FillReceived, memo: str, lines: list[JournalLine]) -> JournalEntry:
+
+        return JournalEntry(
+            timestamp=event.timestamp,
+            trade_id=event.trade_id,
+            command_id=event.command_id,
+            memo=memo,
+            lines=tuple(lines),
+        )
+
+    def _post(self, entry: JournalEntry) -> None:
+
+        with self._lock:
+            self.journal.append(entry)
+
+            for line in entry.lines:
+                delta = line.debit - line.credit if is_debit_normal(line.account) else line.credit - line.debit
+                self.balances[line.account] += delta

--- a/praxis/core/account_ledger.py
+++ b/praxis/core/account_ledger.py
@@ -25,6 +25,7 @@ from praxis.core.domain.chart_of_accounts import Account, is_debit_normal
 from praxis.core.domain.enums import OrderSide
 from praxis.core.domain.events import Event, FillReceived, TradeClosed
 from praxis.core.domain.journal_entry import JournalEntry, JournalLine
+from praxis.core.domain.trade_pnl import TradePnL
 
 __all__ = ['AccountLedger', 'CostBasisMethod']
 
@@ -76,6 +77,7 @@ class AccountLedger:
         self.account_id = account_id
         self.cost_basis_method = cost_basis_method
         self.balances: dict[Account, Decimal] = dict.fromkeys(Account, _ZERO)
+        self.trades: dict[str, TradePnL] = {}
         self.journal: list[JournalEntry] = []
         self._lots: dict[str, deque[_Lot]] = {}
         self._lock = threading.Lock()
@@ -92,7 +94,7 @@ class AccountLedger:
             self._on_fill_received(event)
 
         elif isinstance(event, TradeClosed):
-            return
+            self._on_trade_closed(event)
 
     def _on_fill_received(self, event: FillReceived) -> None:
 
@@ -101,10 +103,21 @@ class AccountLedger:
             raise NotImplementedError(msg)
 
         if event.side is OrderSide.BUY:
-            self._post(self._buy_entry(event))
+            entry = self._buy_entry(event)
+            realized = _ZERO
 
         else:
-            self._post(self._sell_entry(event))
+            entry, realized = self._sell_entry(event)
+
+        self._post(entry, event.trade_id, realized, event.fee)
+
+    def _on_trade_closed(self, event: TradeClosed) -> None:
+
+        with self._lock:
+            trade = self.trades.get(event.trade_id)
+
+            if trade is not None:
+                trade.closed = True
 
     def _buy_entry(self, event: FillReceived) -> JournalEntry:
 
@@ -132,7 +145,7 @@ class AccountLedger:
 
         lots.append(_Lot(qty, price))
 
-    def _sell_entry(self, event: FillReceived) -> JournalEntry:
+    def _sell_entry(self, event: FillReceived) -> tuple[JournalEntry, Decimal]:
 
         proceeds = event.qty * event.price
         cost = self._consume_lots(event.trade_id, event.qty)
@@ -150,7 +163,7 @@ class AccountLedger:
 
         lines.extend(self._fee_lines(event.fee))
 
-        return self._entry(event, 'sell fill', lines)
+        return self._entry(event, 'sell fill', lines), realized
 
     def _consume_lots(self, trade_id: str, qty: Decimal) -> Decimal:
 
@@ -197,7 +210,7 @@ class AccountLedger:
             lines=tuple(lines),
         )
 
-    def _post(self, entry: JournalEntry) -> None:
+    def _post(self, entry: JournalEntry, trade_id: str, realized: Decimal, fee: Decimal) -> None:
 
         with self._lock:
             self.journal.append(entry)
@@ -205,3 +218,7 @@ class AccountLedger:
             for line in entry.lines:
                 delta = line.debit - line.credit if is_debit_normal(line.account) else line.credit - line.debit
                 self.balances[line.account] += delta
+
+            trade = self.trades.setdefault(trade_id, TradePnL(trade_id))
+            trade.realized_gross += realized
+            trade.fees += fee

--- a/praxis/core/account_ledger.py
+++ b/praxis/core/account_ledger.py
@@ -87,10 +87,15 @@ class AccountLedger:
             event: Domain event to project.
 
         Raises:
-            ValueError: A `RegisterAccount` re-registers an already-registered
-                account, or a fill or trade-closed event arrives before the
-                account is registered.
+            ValueError: The event belongs to a different account, a
+                `RegisterAccount` re-registers an already-registered account,
+                or a fill or trade-closed event arrives before the account is
+                registered.
         '''
+
+        if event.account_id != self.account_id:
+            msg = f'event for account {event.account_id!r} routed to the ledger for {self.account_id!r}'
+            raise ValueError(msg)
 
         with self._lock:
 

--- a/praxis/core/account_ledger.py
+++ b/praxis/core/account_ledger.py
@@ -19,12 +19,11 @@ import threading
 from collections import deque
 from dataclasses import dataclass
 from decimal import Decimal
-from enum import Enum
 from typing import Any
 
 from praxis.core.domain.chart_of_accounts import Account, is_debit_normal
-from praxis.core.domain.enums import OrderSide
-from praxis.core.domain.events import Event, FillReceived, TradeClosed
+from praxis.core.domain.enums import CostBasisMethod, OrderSide
+from praxis.core.domain.events import Event, FillReceived, RegisterAccount, TradeClosed
 from praxis.core.domain.journal_entry import JournalEntry, JournalLine
 from praxis.core.domain.trade_pnl import TradePnL
 
@@ -34,14 +33,6 @@ _log = logging.getLogger(__name__)
 
 _ZERO = Decimal(0)
 _QUOTE_ASSET = 'USDT'
-
-
-class CostBasisMethod(Enum):
-
-    '''Cost-basis method for realizing P&L on a sell.'''
-
-    FIFO = 'FIFO'
-    AVERAGE = 'AVERAGE'
 
 
 @dataclass
@@ -55,32 +46,27 @@ class AccountLedger:
 
     '''In-memory double-entry ledger projection for one account.
 
+    The ledger starts unregistered: a `RegisterAccount` event fixes the
+    per-account `cost_basis_method` immutably and must be applied before any
+    fill or trade-closed event.
+
     Args:
         account_id: Account this ledger belongs to.
-        cost_basis_method: Method for realizing P&L on a sell — `FIFO` or
-            `AVERAGE` (weighted average). Set immutably per account.
     '''
 
-    def __init__(
-        self,
-        account_id: str,
-        cost_basis_method: CostBasisMethod = CostBasisMethod.FIFO,
-    ) -> None:
+    def __init__(self, account_id: str) -> None:
 
         if not account_id:
             msg = 'AccountLedger.account_id must be a non-empty string'
             raise ValueError(msg)
 
-        if not isinstance(cost_basis_method, CostBasisMethod):
-            msg = f'unsupported cost_basis_method: {cost_basis_method}'
-            raise ValueError(msg)
-
         self.account_id = account_id
-        self.cost_basis_method = cost_basis_method
+        self.cost_basis_method: CostBasisMethod | None = None
         self.balances: dict[Account, Decimal] = dict.fromkeys(Account, _ZERO)
         self.trades: dict[str, TradePnL] = {}
         self.journal: list[JournalEntry] = []
         self._lots: dict[str, deque[_Lot]] = {}
+        self._registered = False
         self._lock = threading.Lock()
 
     def apply(self, event: Event) -> None:
@@ -89,7 +75,21 @@ class AccountLedger:
 
         Args:
             event: Domain event to project.
+
+        Raises:
+            ValueError: A `RegisterAccount` re-registers an already-registered
+                account, or a fill or trade-closed event arrives before the
+                account is registered.
         '''
+
+        if isinstance(event, RegisterAccount):
+            self._on_register_account(event)
+
+            return
+
+        if not self._registered:
+            msg = f'account {self.account_id!r} not registered; apply RegisterAccount first'
+            raise ValueError(msg)
 
         if isinstance(event, FillReceived):
             self._on_fill_received(event)
@@ -109,7 +109,8 @@ class AccountLedger:
         with self._lock:
             return {
                 'account_id': self.account_id,
-                'cost_basis_method': self.cost_basis_method.value,
+                'registered': self._registered,
+                'cost_basis_method': self.cost_basis_method.value if self.cost_basis_method is not None else None,
                 'balances': {account.value: str(amount) for account, amount in self.balances.items()},
                 'trades': {
                     trade_id: {
@@ -146,7 +147,13 @@ class AccountLedger:
         '''Rebuild a ledger from a `to_snapshot` payload (journal not restored).'''
 
         state = snapshot['state']
-        ledger = cls(state['account_id'], CostBasisMethod(state['cost_basis_method']))
+        ledger = cls(state['account_id'])
+
+        method = state['cost_basis_method']
+        if method is not None:
+            ledger.cost_basis_method = CostBasisMethod(method)
+
+        ledger._registered = state.get('registered', method is not None)
 
         for account_value, amount in state['balances'].items():
             ledger.balances[Account(account_value)] = Decimal(amount)
@@ -161,6 +168,16 @@ class AccountLedger:
         }
 
         return ledger
+
+    def _on_register_account(self, event: RegisterAccount) -> None:
+
+        with self._lock:
+            if self._registered:
+                msg = f'account {self.account_id!r} already registered; cost_basis_method is immutable'
+                raise ValueError(msg)
+
+            self.cost_basis_method = CostBasisMethod(event.cost_basis_method)
+            self._registered = True
 
     def _on_fill_received(self, event: FillReceived) -> None:
 

--- a/praxis/core/account_ledger.py
+++ b/praxis/core/account_ledger.py
@@ -9,7 +9,10 @@ independent store.
 Cost basis is chosen per account — FIFO or weighted-average (AVERAGE).
 Fees are expensed to `Expense:Fees`; the base asset is carried at trade
 price (fees are not capitalised), so realized P&L is the proceeds less the
-lot cost (FIFO or average) and fees stand alone.
+lot cost (FIFO or average) and fees stand alone. A quote-asset (`USDT`)
+fee credits `Cash:USDT`; a base-asset (`BTC`) fee — charged on a buy — is
+valued at the fill price, credits `Crypto:BTC`, and reduces the booked lot
+to the net quantity received. Any other fee asset is unsupported.
 '''
 
 from __future__ import annotations
@@ -33,6 +36,7 @@ _log = logging.getLogger(__name__)
 
 _ZERO = Decimal(0)
 _QUOTE_ASSET = 'USDT'
+_BASE_ASSET = 'BTC'
 
 
 @dataclass
@@ -181,18 +185,14 @@ class AccountLedger:
 
     def _on_fill_received(self, event: FillReceived) -> None:
 
-        if event.fee_asset != _QUOTE_ASSET:
-            msg = f'fee_asset {event.fee_asset!r} not yet supported (only {_QUOTE_ASSET})'
-            raise NotImplementedError(msg)
-
         if event.side is OrderSide.BUY:
-            entry = self._buy_entry(event)
+            entry, fee_value = self._buy_entry(event)
             realized = _ZERO
 
         else:
-            entry, realized = self._sell_entry(event)
+            entry, realized, fee_value = self._sell_entry(event)
 
-        self._post(entry, event.trade_id, realized, event.fee)
+        self._post(entry, event.trade_id, realized, fee_value)
 
     def _on_trade_closed(self, event: TradeClosed) -> None:
 
@@ -202,17 +202,31 @@ class AccountLedger:
             if trade is not None:
                 trade.closed = True
 
-    def _buy_entry(self, event: FillReceived) -> JournalEntry:
+    def _buy_entry(self, event: FillReceived) -> tuple[JournalEntry, Decimal]:
 
         notional = event.qty * event.price
         lines = [
             JournalLine(Account.CRYPTO_BTC, notional, _ZERO),
             JournalLine(Account.CASH_USDT, _ZERO, notional),
         ]
-        lines.extend(self._fee_lines(event.fee))
-        self._add_lot(event.trade_id, event.qty, event.price)
 
-        return self._entry(event, 'buy fill', lines)
+        if event.fee_asset == _QUOTE_ASSET:
+            fee_value = event.fee
+            lines.extend(self._fee_lines(fee_value, Account.CASH_USDT))
+            lot_qty = event.qty
+
+        elif event.fee_asset == _BASE_ASSET:
+            fee_value = event.fee * event.price
+            lines.extend(self._fee_lines(fee_value, Account.CRYPTO_BTC))
+            lot_qty = event.qty - event.fee
+
+        else:
+            msg = f'fee_asset {event.fee_asset!r} not supported for a buy fill'
+            raise NotImplementedError(msg)
+
+        self._add_lot(event.trade_id, lot_qty, event.price)
+
+        return self._entry(event, 'buy fill', lines), fee_value
 
     def _add_lot(self, trade_id: str, qty: Decimal, price: Decimal) -> None:
 
@@ -228,7 +242,11 @@ class AccountLedger:
 
         lots.append(_Lot(qty, price))
 
-    def _sell_entry(self, event: FillReceived) -> tuple[JournalEntry, Decimal]:
+    def _sell_entry(self, event: FillReceived) -> tuple[JournalEntry, Decimal, Decimal]:
+
+        if event.fee_asset != _QUOTE_ASSET:
+            msg = f'fee_asset {event.fee_asset!r} not supported for a sell fill'
+            raise NotImplementedError(msg)
 
         proceeds = event.qty * event.price
         cost = self._consume_lots(event.trade_id, event.qty)
@@ -244,9 +262,9 @@ class AccountLedger:
         elif realized < _ZERO:
             lines.append(JournalLine(Account.REALIZED_PNL, -realized, _ZERO))
 
-        lines.extend(self._fee_lines(event.fee))
+        lines.extend(self._fee_lines(event.fee, Account.CASH_USDT))
 
-        return self._entry(event, 'sell fill', lines), realized
+        return self._entry(event, 'sell fill', lines), realized, event.fee
 
     def _consume_lots(self, trade_id: str, qty: Decimal) -> Decimal:
 
@@ -272,14 +290,14 @@ class AccountLedger:
         return cost
 
     @staticmethod
-    def _fee_lines(fee: Decimal) -> list[JournalLine]:
+    def _fee_lines(fee_value: Decimal, credit_account: Account) -> list[JournalLine]:
 
-        if fee <= _ZERO:
+        if fee_value <= _ZERO:
             return []
 
         return [
-            JournalLine(Account.FEES, fee, _ZERO),
-            JournalLine(Account.CASH_USDT, _ZERO, fee),
+            JournalLine(Account.FEES, fee_value, _ZERO),
+            JournalLine(credit_account, _ZERO, fee_value),
         ]
 
     @staticmethod

--- a/praxis/core/account_ledger.py
+++ b/praxis/core/account_ledger.py
@@ -20,6 +20,7 @@ from collections import deque
 from dataclasses import dataclass
 from decimal import Decimal
 from enum import Enum
+from typing import Any
 
 from praxis.core.domain.chart_of_accounts import Account, is_debit_normal
 from praxis.core.domain.enums import OrderSide
@@ -95,6 +96,71 @@ class AccountLedger:
 
         elif isinstance(event, TradeClosed):
             self._on_trade_closed(event)
+
+    def state(self) -> dict[str, Any]:
+
+        '''Return the resumable projection state as a JSON-serialisable dict.
+
+        Holds balances, per-trade P&L, and open cost-basis lots — the
+        derived state needed to resume without replaying from genesis.
+        The journal is the audit trail and is not part of this state.
+        '''
+
+        with self._lock:
+            return {
+                'account_id': self.account_id,
+                'cost_basis_method': self.cost_basis_method.value,
+                'balances': {account.value: str(amount) for account, amount in self.balances.items()},
+                'trades': {
+                    trade_id: {
+                        'realized_gross': str(trade.realized_gross),
+                        'fees': str(trade.fees),
+                        'closed': trade.closed,
+                    }
+                    for trade_id, trade in self.trades.items()
+                },
+                'lots': {
+                    trade_id: [{'qty': str(lot.qty), 'unit_cost': str(lot.unit_cost)} for lot in lots]
+                    for trade_id, lots in self._lots.items()
+                },
+            }
+
+    def to_snapshot(self, last_applied_event_seq: int, epoch_id: int) -> dict[str, Any]:
+
+        '''Return a snapshot of the ledger tagged with its spine position.
+
+        Args:
+            last_applied_event_seq: Sequence of the last event applied.
+            epoch_id: Epoch the snapshot belongs to.
+        '''
+
+        return {
+            'last_applied_event_seq': last_applied_event_seq,
+            'epoch_id': epoch_id,
+            'state': self.state(),
+        }
+
+    @classmethod
+    def from_snapshot(cls, snapshot: dict[str, Any]) -> AccountLedger:
+
+        '''Rebuild a ledger from a `to_snapshot` payload (journal not restored).'''
+
+        state = snapshot['state']
+        ledger = cls(state['account_id'], CostBasisMethod(state['cost_basis_method']))
+
+        for account_value, amount in state['balances'].items():
+            ledger.balances[Account(account_value)] = Decimal(amount)
+
+        ledger.trades = {
+            trade_id: TradePnL(trade_id, Decimal(t['realized_gross']), Decimal(t['fees']), t['closed'])
+            for trade_id, t in state['trades'].items()
+        }
+        ledger._lots = {
+            trade_id: deque(_Lot(Decimal(lot['qty']), Decimal(lot['unit_cost'])) for lot in lots)
+            for trade_id, lots in state['lots'].items()
+        }
+
+        return ledger
 
     def _on_fill_received(self, event: FillReceived) -> None:
 

--- a/praxis/core/account_ledger.py
+++ b/praxis/core/account_ledger.py
@@ -43,6 +43,7 @@ _log = logging.getLogger(__name__)
 _ZERO = Decimal(0)
 _QUOTE_ASSET = 'USDT'
 _BASE_ASSET = 'BTC'
+_SYMBOL = 'BTCUSDT'
 
 
 @dataclass
@@ -213,6 +214,10 @@ class AccountLedger:
         self._registered = True
 
     def _on_fill_received(self, event: FillReceived) -> None:
+
+        if event.symbol != _SYMBOL:
+            msg = f'symbol {event.symbol!r} not supported; the ledger books only {_SYMBOL}'
+            raise NotImplementedError(msg)
 
         if event.side is OrderSide.BUY:
             entry, fee_value = self._buy_entry(event)

--- a/praxis/core/account_ledger.py
+++ b/praxis/core/account_ledger.py
@@ -266,6 +266,10 @@ class AccountLedger:
             lot_qty = event.qty
 
         elif event.fee_asset == _BASE_ASSET:
+            if event.fee >= event.qty:
+                msg = f'base-asset fee {event.fee} must be smaller than the filled qty {event.qty}'
+                raise ValueError(msg)
+
             fee_value = event.fee * event.price
             lines.extend(self._fee_lines(fee_value, Account.CRYPTO_BTC))
             lot_qty = event.qty - event.fee

--- a/praxis/core/account_ledger.py
+++ b/praxis/core/account_ledger.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import logging
 import threading
 from collections import deque
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from decimal import Decimal
 from typing import Any
 
@@ -138,6 +138,20 @@ class AccountLedger:
                     for trade_id, lots in self._lots.items()
                 },
             }
+
+    def read_balances(self) -> dict[Account, Decimal]:
+
+        '''Return a copy of the current account balances by ledger account.'''
+
+        with self._lock:
+            return dict(self.balances)
+
+    def read_trade_pnls(self) -> dict[str, TradePnL]:
+
+        '''Return copies of the per-trade realized P&L, keyed by `trade_id`.'''
+
+        with self._lock:
+            return {trade_id: replace(trade) for trade_id, trade in self.trades.items()}
 
     def to_snapshot(self, last_applied_event_seq: int, epoch_id: int) -> dict[str, Any]:
 

--- a/praxis/core/account_ledger.py
+++ b/praxis/core/account_ledger.py
@@ -92,23 +92,25 @@ class AccountLedger:
                 account is registered.
         '''
 
-        if isinstance(event, RegisterAccount):
-            self._on_register_account(event)
+        with self._lock:
 
-            return
+            if isinstance(event, RegisterAccount):
+                self._on_register_account(event)
 
-        if not self._registered:
-            msg = f'account {self.account_id!r} not registered; apply RegisterAccount first'
-            raise ValueError(msg)
+                return
 
-        if isinstance(event, FillReceived):
-            self._on_fill_received(event)
+            if not self._registered:
+                msg = f'account {self.account_id!r} not registered; apply RegisterAccount first'
+                raise ValueError(msg)
 
-        elif isinstance(event, TradeClosed):
-            self._on_trade_closed(event)
+            if isinstance(event, FillReceived):
+                self._on_fill_received(event)
 
-        elif isinstance(event, FundTransaction):
-            self._on_fund_transaction(event)
+            elif isinstance(event, TradeClosed):
+                self._on_trade_closed(event)
+
+            elif isinstance(event, FundTransaction):
+                self._on_fund_transaction(event)
 
     def state(self) -> dict[str, Any]:
 
@@ -198,13 +200,12 @@ class AccountLedger:
 
     def _on_register_account(self, event: RegisterAccount) -> None:
 
-        with self._lock:
-            if self._registered:
-                msg = f'account {self.account_id!r} already registered; cost_basis_method is immutable'
-                raise ValueError(msg)
+        if self._registered:
+            msg = f'account {self.account_id!r} already registered; cost_basis_method is immutable'
+            raise ValueError(msg)
 
-            self.cost_basis_method = CostBasisMethod(event.cost_basis_method)
-            self._registered = True
+        self.cost_basis_method = CostBasisMethod(event.cost_basis_method)
+        self._registered = True
 
     def _on_fill_received(self, event: FillReceived) -> None:
 
@@ -219,11 +220,10 @@ class AccountLedger:
 
     def _on_trade_closed(self, event: TradeClosed) -> None:
 
-        with self._lock:
-            trade = self.trades.get(event.trade_id)
+        trade = self.trades.get(event.trade_id)
 
-            if trade is not None:
-                trade.closed = True
+        if trade is not None:
+            trade.closed = True
 
     def _on_fund_transaction(self, event: FundTransaction) -> None:
 
@@ -249,8 +249,7 @@ class AccountLedger:
             lines=tuple(lines),
         )
 
-        with self._lock:
-            self._post_entry(entry)
+        self._post_entry(entry)
 
     def _buy_entry(self, event: FillReceived) -> tuple[JournalEntry, Decimal]:
 
@@ -375,9 +374,8 @@ class AccountLedger:
 
     def _post(self, entry: JournalEntry, trade_id: str, realized: Decimal, fee: Decimal) -> None:
 
-        with self._lock:
-            self._post_entry(entry)
+        self._post_entry(entry)
 
-            trade = self.trades.setdefault(trade_id, TradePnL(trade_id))
-            trade.realized_gross += realized
-            trade.fees += fee
+        trade = self.trades.setdefault(trade_id, TradePnL(trade_id))
+        trade.realized_gross += realized
+        trade.fees += fee

--- a/praxis/core/account_ledger.py
+++ b/praxis/core/account_ledger.py
@@ -25,8 +25,14 @@ from decimal import Decimal
 from typing import Any
 
 from praxis.core.domain.chart_of_accounts import Account, is_debit_normal
-from praxis.core.domain.enums import CostBasisMethod, OrderSide
-from praxis.core.domain.events import Event, FillReceived, RegisterAccount, TradeClosed
+from praxis.core.domain.enums import CostBasisMethod, FundDirection, OrderSide
+from praxis.core.domain.events import (
+    Event,
+    FillReceived,
+    FundTransaction,
+    RegisterAccount,
+    TradeClosed,
+)
 from praxis.core.domain.journal_entry import JournalEntry, JournalLine
 from praxis.core.domain.trade_pnl import TradePnL
 
@@ -100,6 +106,9 @@ class AccountLedger:
 
         elif isinstance(event, TradeClosed):
             self._on_trade_closed(event)
+
+        elif isinstance(event, FundTransaction):
+            self._on_fund_transaction(event)
 
     def state(self) -> dict[str, Any]:
 
@@ -201,6 +210,33 @@ class AccountLedger:
 
             if trade is not None:
                 trade.closed = True
+
+    def _on_fund_transaction(self, event: FundTransaction) -> None:
+
+        if event.direction == FundDirection.DEPOSIT.value:
+            lines = [
+                JournalLine(Account.CASH_USDT, event.amount, _ZERO),
+                JournalLine(Account.CONTRIBUTIONS, _ZERO, event.amount),
+            ]
+            memo = 'deposit'
+
+        else:
+            lines = [
+                JournalLine(Account.CONTRIBUTIONS, event.amount, _ZERO),
+                JournalLine(Account.CASH_USDT, _ZERO, event.amount),
+            ]
+            memo = 'withdrawal'
+
+        entry = JournalEntry(
+            timestamp=event.timestamp,
+            source_event_type='FundTransaction',
+            source_event_id=event.fund_transaction_id,
+            memo=memo,
+            lines=tuple(lines),
+        )
+
+        with self._lock:
+            self._post_entry(entry)
 
     def _buy_entry(self, event: FillReceived) -> tuple[JournalEntry, Decimal]:
 
@@ -305,20 +341,24 @@ class AccountLedger:
 
         return JournalEntry(
             timestamp=event.timestamp,
-            trade_id=event.trade_id,
-            command_id=event.command_id,
+            source_event_type='FillReceived',
+            source_event_id=event.venue_trade_id,
             memo=memo,
             lines=tuple(lines),
         )
 
+    def _post_entry(self, entry: JournalEntry) -> None:
+
+        self.journal.append(entry)
+
+        for line in entry.lines:
+            delta = line.debit - line.credit if is_debit_normal(line.account) else line.credit - line.debit
+            self.balances[line.account] += delta
+
     def _post(self, entry: JournalEntry, trade_id: str, realized: Decimal, fee: Decimal) -> None:
 
         with self._lock:
-            self.journal.append(entry)
-
-            for line in entry.lines:
-                delta = line.debit - line.credit if is_debit_normal(line.account) else line.credit - line.debit
-                self.balances[line.account] += delta
+            self._post_entry(entry)
 
             trade = self.trades.setdefault(trade_id, TradePnL(trade_id))
             trade.realized_gross += realized

--- a/praxis/core/domain/chart_of_accounts.py
+++ b/praxis/core/domain/chart_of_accounts.py
@@ -1,0 +1,43 @@
+'''Chart of accounts for the Praxis double-entry ledger (Account sub-system).
+
+Accounts are carried in the quote asset (USDT). `Crypto:BTC` holds the
+base asset at cost. Each account has a normal balance side: assets and
+expenses are debit-normal (a debit increases them), income and equity are
+credit-normal (a credit increases them).
+'''
+
+from __future__ import annotations
+
+from enum import Enum
+
+__all__ = ['Account', 'is_debit_normal']
+
+
+class Account(Enum):
+
+    '''A ledger account in the chart of accounts.'''
+
+    CASH_USDT = 'Cash:USDT'
+    CRYPTO_BTC = 'Crypto:BTC'
+    REALIZED_PNL = 'Income:RealizedPnL'
+    FEES = 'Expense:Fees'
+    CONTRIBUTIONS = 'Equity:Contributions'
+
+
+_DEBIT_NORMAL = frozenset({Account.CASH_USDT, Account.CRYPTO_BTC, Account.FEES})
+
+
+def is_debit_normal(account: Account) -> bool:
+
+    '''Return whether `account` increases on the debit side.
+
+    Args:
+        account: The account to classify.
+
+    Returns:
+        True for asset and expense accounts (`Cash:USDT`, `Crypto:BTC`,
+        `Expense:Fees`); False for income and equity accounts
+        (`Income:RealizedPnL`, `Equity:Contributions`).
+    '''
+
+    return account in _DEBIT_NORMAL

--- a/praxis/core/domain/enums.py
+++ b/praxis/core/domain/enums.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from enum import Enum
 
 
-__all__ = ['CostBasisMethod', 'ExecutionMode', 'ExecutionType', 'MakerPreference', 'OrderSide', 'OrderStatus', 'OrderType', 'STPMode', 'TradeStatus']
+__all__ = ['CostBasisMethod', 'ExecutionMode', 'ExecutionType', 'FundDirection', 'MakerPreference', 'OrderSide', 'OrderStatus', 'OrderType', 'STPMode', 'TradeStatus']
 
 
 class OrderSide(Enum):
@@ -27,6 +27,14 @@ class CostBasisMethod(Enum):
 
     FIFO = 'FIFO'
     AVERAGE = 'AVERAGE'
+
+
+class FundDirection(Enum):
+
+    '''Direction of a fund transaction on an account.'''
+
+    DEPOSIT = 'DEPOSIT'
+    WITHDRAWAL = 'WITHDRAWAL'
 
 
 class OrderType(Enum):

--- a/praxis/core/domain/enums.py
+++ b/praxis/core/domain/enums.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from enum import Enum
 
 
-__all__ = ['ExecutionMode', 'ExecutionType', 'MakerPreference', 'OrderSide', 'OrderStatus', 'OrderType', 'STPMode', 'TradeStatus']
+__all__ = ['CostBasisMethod', 'ExecutionMode', 'ExecutionType', 'MakerPreference', 'OrderSide', 'OrderStatus', 'OrderType', 'STPMode', 'TradeStatus']
 
 
 class OrderSide(Enum):
@@ -19,6 +19,14 @@ class OrderSide(Enum):
 
     BUY = 'BUY'
     SELL = 'SELL'
+
+
+class CostBasisMethod(Enum):
+
+    '''Cost-basis method for realizing P&L on a sell.'''
+
+    FIFO = 'FIFO'
+    AVERAGE = 'AVERAGE'
 
 
 class OrderType(Enum):

--- a/praxis/core/domain/events.py
+++ b/praxis/core/domain/events.py
@@ -14,7 +14,7 @@ from datetime import datetime
 from decimal import Decimal
 
 from praxis.core.domain._require_str import _require_str
-from praxis.core.domain.enums import OrderSide, OrderType, TradeStatus
+from praxis.core.domain.enums import CostBasisMethod, OrderSide, OrderType, TradeStatus
 
 __all__ = [
     'CommandAccepted',
@@ -31,11 +31,13 @@ __all__ = [
     'OutcomeAcked',
     'OutcomeDeliveryContextRecorded',
     'OutcomeReplayAbandoned',
+    'RegisterAccount',
     'TradeClosed',
     'TradeOutcomeProduced',
 ]
 
 _ZERO = Decimal(0)
+_COST_BASIS_METHOD_VALUES = frozenset(method.value for method in CostBasisMethod)
 
 
 @dataclass(frozen=True)
@@ -465,6 +467,34 @@ class MarkSampled(_EventBase):
 
         if not self.mark_price.is_finite() or self.mark_price <= _ZERO:
             msg = 'MarkSampled.mark_price must be a positive finite Decimal'
+            raise ValueError(msg)
+
+
+@dataclass(frozen=True)
+class RegisterAccount(_EventBase):
+
+    '''
+    Represent registration of an account with its immutable cost-basis method.
+
+    Args:
+        account_id (str): Account that owns this event.
+        timestamp (datetime): Event time, must be timezone-aware.
+        cost_basis_method (str): Cost-basis method fixed for the account's
+            lifetime, one of 'FIFO' or 'AVERAGE'. Defaults to 'FIFO'.
+    '''
+
+    cost_basis_method: str = CostBasisMethod.FIFO.value
+
+    def __post_init__(self) -> None:
+
+        super().__post_init__()
+
+        name = type(self).__name__
+        _require_str(name, 'cost_basis_method', self.cost_basis_method)
+
+        if self.cost_basis_method not in _COST_BASIS_METHOD_VALUES:
+            allowed = ', '.join(sorted(_COST_BASIS_METHOD_VALUES))
+            msg = f'{name}.cost_basis_method must be one of {allowed}'
             raise ValueError(msg)
 
 

--- a/praxis/core/domain/events.py
+++ b/praxis/core/domain/events.py
@@ -727,4 +727,5 @@ type Event = (
     | OutcomeDeliveryContextRecorded
     | OutcomeReplayAbandoned
     | MarkSampled
+    | RegisterAccount
 )

--- a/praxis/core/domain/events.py
+++ b/praxis/core/domain/events.py
@@ -14,12 +14,13 @@ from datetime import datetime
 from decimal import Decimal
 
 from praxis.core.domain._require_str import _require_str
-from praxis.core.domain.enums import CostBasisMethod, OrderSide, OrderType, TradeStatus
+from praxis.core.domain.enums import CostBasisMethod, FundDirection, OrderSide, OrderType, TradeStatus
 
 __all__ = [
     'CommandAccepted',
     'Event',
     'FillReceived',
+    'FundTransaction',
     'MarkSampled',
     'OrderAcked',
     'OrderCanceled',
@@ -38,6 +39,7 @@ __all__ = [
 
 _ZERO = Decimal(0)
 _COST_BASIS_METHOD_VALUES = frozenset(method.value for method in CostBasisMethod)
+_FUND_DIRECTION_VALUES = frozenset(direction.value for direction in FundDirection)
 
 
 @dataclass(frozen=True)
@@ -499,6 +501,41 @@ class RegisterAccount(_EventBase):
 
 
 @dataclass(frozen=True)
+class FundTransaction(_EventBase):
+
+    '''
+    Represent a deposit or withdrawal of quote-asset funds on an account.
+
+    Args:
+        account_id (str): Account that owns this event.
+        timestamp (datetime): Event time, must be timezone-aware.
+        fund_transaction_id (str): Stable unique identifier for the transaction.
+        amount (Decimal): Quote-asset amount moved, must be positive and finite.
+        direction (str): 'DEPOSIT' or 'WITHDRAWAL'.
+    '''
+
+    fund_transaction_id: str
+    amount: Decimal
+    direction: str
+
+    def __post_init__(self) -> None:
+
+        super().__post_init__()
+
+        name = type(self).__name__
+        _require_str(name, 'fund_transaction_id', self.fund_transaction_id)
+
+        if not self.amount.is_finite() or self.amount <= _ZERO:
+            msg = f'{name}.amount must be a positive finite Decimal'
+            raise ValueError(msg)
+
+        if self.direction not in _FUND_DIRECTION_VALUES:
+            allowed = ', '.join(sorted(_FUND_DIRECTION_VALUES))
+            msg = f'{name}.direction must be one of {allowed}'
+            raise ValueError(msg)
+
+
+@dataclass(frozen=True)
 class TradeOutcomeProduced(_EventBase):
 
     '''
@@ -728,4 +765,5 @@ type Event = (
     | OutcomeReplayAbandoned
     | MarkSampled
     | RegisterAccount
+    | FundTransaction
 )

--- a/praxis/core/domain/journal_entry.py
+++ b/praxis/core/domain/journal_entry.py
@@ -70,6 +70,10 @@ class JournalEntry:
 
     def __post_init__(self) -> None:
 
+        if self.timestamp.tzinfo is None or self.timestamp.utcoffset() is None:
+            msg = 'JournalEntry.timestamp must be timezone-aware'
+            raise ValueError(msg)
+
         if not self.lines:
             msg = 'JournalEntry must have at least one line'
             raise ValueError(msg)

--- a/praxis/core/domain/journal_entry.py
+++ b/praxis/core/domain/journal_entry.py
@@ -55,15 +55,16 @@ class JournalEntry:
 
     Args:
         timestamp: Event time, timezone-aware.
-        trade_id: Trade correlation identifier the entry posts against.
-        command_id: Originating command identifier.
+        source_event_type: Type name of the spine event this entry derives
+            from, e.g. `'FillReceived'` or `'FundTransaction'`.
+        source_event_id: Stable identifier of that source event.
         memo: Short human-readable description of the entry.
         lines: The debit and credit lines; total debits equal total credits.
     '''
 
     timestamp: datetime
-    trade_id: str
-    command_id: str
+    source_event_type: str
+    source_event_id: str
     memo: str
     lines: tuple[JournalLine, ...]
 

--- a/praxis/core/domain/journal_entry.py
+++ b/praxis/core/domain/journal_entry.py
@@ -1,0 +1,81 @@
+'''Balanced double-entry journal records for the Account sub-system.
+
+A `JournalEntry` is an immutable, balanced set of `JournalLine`s derived
+from one Event Spine event. Balanced means total debits equal total
+credits; the constructor rejects any entry that is not.
+'''
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+
+from praxis.core.domain.chart_of_accounts import Account
+
+__all__ = ['JournalEntry', 'JournalLine']
+
+_ZERO = Decimal(0)
+
+
+@dataclass(frozen=True)
+class JournalLine:
+
+    '''One leg of a journal entry: a debit or a credit to one account.
+
+    Args:
+        account: The account this line posts to.
+        debit: Amount posted to the debit side, in the quote asset.
+        credit: Amount posted to the credit side, in the quote asset.
+    '''
+
+    account: Account
+    debit: Decimal
+    credit: Decimal
+
+    def __post_init__(self) -> None:
+
+        if not self.debit.is_finite() or not self.credit.is_finite():
+            msg = f'JournalLine amounts must be finite: {self.debit}, {self.credit}'
+            raise ValueError(msg)
+
+        if self.debit < _ZERO or self.credit < _ZERO:
+            msg = f'JournalLine amounts must be non-negative: {self.debit}, {self.credit}'
+            raise ValueError(msg)
+
+        if self.debit > _ZERO and self.credit > _ZERO:
+            msg = f'JournalLine must be one-sided, got debit={self.debit} credit={self.credit}'
+            raise ValueError(msg)
+
+
+@dataclass(frozen=True)
+class JournalEntry:
+
+    '''A balanced set of journal lines posted from one event.
+
+    Args:
+        timestamp: Event time, timezone-aware.
+        trade_id: Trade correlation identifier the entry posts against.
+        command_id: Originating command identifier.
+        memo: Short human-readable description of the entry.
+        lines: The debit and credit lines; total debits equal total credits.
+    '''
+
+    timestamp: datetime
+    trade_id: str
+    command_id: str
+    memo: str
+    lines: tuple[JournalLine, ...]
+
+    def __post_init__(self) -> None:
+
+        if not self.lines:
+            msg = 'JournalEntry must have at least one line'
+            raise ValueError(msg)
+
+        total_debits = sum((line.debit for line in self.lines), _ZERO)
+        total_credits = sum((line.credit for line in self.lines), _ZERO)
+
+        if total_debits != total_credits:
+            msg = f'JournalEntry not balanced: debits={total_debits} credits={total_credits}'
+            raise ValueError(msg)

--- a/praxis/core/domain/trade_pnl.py
+++ b/praxis/core/domain/trade_pnl.py
@@ -1,0 +1,40 @@
+'''Per-trade realized P&L record for the Account sub-system.
+
+Accumulated by `AccountLedger` per `trade_id`: realized gross P&L from
+sells (proceeds less lot cost), the trade's fees, and whether the trade
+has been closed. Net P&L is gross less fees.
+'''
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+__all__ = ['TradePnL']
+
+_ZERO = Decimal(0)
+
+
+@dataclass
+class TradePnL:
+
+    '''Realized P&L accumulated for one trade (`trade_id`).
+
+    Args:
+        trade_id: Trade correlation identifier.
+        realized_gross: Realized P&L from sells, before fees.
+        fees: Total fees booked against this trade.
+        closed: Whether a `TradeClosed` event has finalized the trade.
+    '''
+
+    trade_id: str
+    realized_gross: Decimal = _ZERO
+    fees: Decimal = _ZERO
+    closed: bool = False
+
+    @property
+    def net(self) -> Decimal:
+
+        '''Return realized P&L net of fees (`realized_gross - fees`).'''
+
+        return self.realized_gross - self.fees

--- a/praxis/core/execution_manager.py
+++ b/praxis/core/execution_manager.py
@@ -19,6 +19,7 @@ from datetime import datetime, timedelta, UTC
 from decimal import Decimal
 
 from praxis.core.account_ledger import AccountLedger
+from praxis.core.domain.chart_of_accounts import Account
 from praxis.core.domain.enums import (
     CostBasisMethod,
     ExecutionMode,
@@ -48,6 +49,7 @@ from praxis.core.domain.events import (
 from praxis.core.domain.order import Order
 from praxis.core.domain.position import Position
 from praxis.core.domain.trade_outcome import TradeOutcome
+from praxis.core.domain.trade_pnl import TradePnL
 from praxis.core.domain.single_shot_params import SingleShotParams
 from praxis.core.domain.trade_abort import TradeAbort
 from praxis.core.domain.trade_command import TradeCommand
@@ -670,6 +672,48 @@ class ExecutionManager:
             raise AccountNotRegisteredError(msg)
 
         return runtime.trading_state.snapshot_positions()
+
+    def get_account_balances(self, account_id: str) -> dict[Account, Decimal]:
+        '''
+        Return a detached snapshot of the account-ledger balances.
+
+        Args:
+            account_id (str): Account identifier to query.
+
+        Returns:
+            dict[Account, Decimal]: Ledger balances by account.
+
+        Raises:
+            AccountNotRegisteredError: If account_id is not registered.
+        '''
+
+        runtime = self._accounts.get(account_id)
+        if runtime is None:
+            msg = f"account_id '{account_id}' is not registered"
+            raise AccountNotRegisteredError(msg)
+
+        return runtime.account_ledger.read_balances()
+
+    def get_account_trade_pnls(self, account_id: str) -> dict[str, TradePnL]:
+        '''
+        Return a detached snapshot of per-trade realized P&L for an account.
+
+        Args:
+            account_id (str): Account identifier to query.
+
+        Returns:
+            dict[str, TradePnL]: Per-trade realized P&L keyed by trade_id.
+
+        Raises:
+            AccountNotRegisteredError: If account_id is not registered.
+        '''
+
+        runtime = self._accounts.get(account_id)
+        if runtime is None:
+            msg = f"account_id '{account_id}' is not registered"
+            raise AccountNotRegisteredError(msg)
+
+        return runtime.account_ledger.read_trade_pnls()
 
     def get_trading_state(self, account_id: str) -> TradingState | None:
         '''

--- a/praxis/core/execution_manager.py
+++ b/praxis/core/execution_manager.py
@@ -18,7 +18,9 @@ from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta, UTC
 from decimal import Decimal
 
+from praxis.core.account_ledger import AccountLedger
 from praxis.core.domain.enums import (
+    CostBasisMethod,
     ExecutionMode,
     MakerPreference,
     OrderSide,
@@ -38,6 +40,7 @@ from praxis.core.domain.events import (
     OrderSubmitFailed,
     OrderSubmitIntent,
     OrderSubmitted,
+    RegisterAccount,
     TradeClosed,
     TradeOutcomeProduced,
 )
@@ -106,6 +109,7 @@ class _AccountRuntime:
         priority_queue (asyncio.Queue[TradeAbort]): Unbounded queue for aborts.
         ws_event_queue (asyncio.Queue[Event]): Unbounded queue for WS events.
         trading_state (TradingState): Per-account state projection.
+        account_ledger (AccountLedger): Per-account double-entry projection.
     '''
 
     def __init__(
@@ -115,14 +119,16 @@ class _AccountRuntime:
         priority_queue: asyncio.Queue[TradeAbort],
         ws_event_queue: asyncio.Queue[Event],
         trading_state: TradingState,
+        account_ledger: AccountLedger,
     ) -> None:
-        '''Store per-account queues and projection.'''
+        '''Store per-account queues and projections.'''
 
         self.account_id = account_id
         self.command_queue = command_queue
         self.priority_queue = priority_queue
         self.ws_event_queue = ws_event_queue
         self.trading_state = trading_state
+        self.account_ledger = account_ledger
         self.task: asyncio.Task[None] | None = None
         self.command_to_order: dict[str, str] = {}
 
@@ -275,6 +281,7 @@ class ExecutionManager:
             priority_queue=asyncio.Queue(),
             ws_event_queue=asyncio.Queue(),
             trading_state=TradingState(account_id),
+            account_ledger=AccountLedger(account_id),
         )
         runtime.task = asyncio.create_task(
             self._account_loop(runtime),
@@ -367,8 +374,10 @@ class ExecutionManager:
             msg = f"account_id '{account_id}' is not registered"
             raise AccountNotRegisteredError(msg)
 
+        self._bridge_legacy_registration(runtime, events)
+
         for _seq, event in events:
-            runtime.trading_state.apply(event)
+            self._project(runtime, event)
 
             if isinstance(event, CommandAccepted):
                 self._accepted_commands[event.command_id] = account_id
@@ -406,6 +415,103 @@ class ExecutionManager:
                         stp_mode=STPMode.NONE,
                         created_at=event.timestamp,
                     )
+
+    def _project(self, runtime: _AccountRuntime, event: Event) -> None:
+        '''Apply an event to the account's trading-state and ledger projections.
+
+        `RegisterAccount` books into the ledger only; `FillReceived` and
+        `TradeClosed` book into both; every other event advances the trading
+        state alone. The ledger is a secondary projection, so a projection
+        failure is logged and never propagated into the trading path.
+        '''
+
+        if isinstance(event, RegisterAccount):
+            self._project_to_ledger(runtime, event)
+
+            return
+
+        runtime.trading_state.apply(event)
+
+        if isinstance(event, FillReceived | TradeClosed):
+            self._project_to_ledger(runtime, event)
+
+    def _project_to_ledger(self, runtime: _AccountRuntime, event: Event) -> None:
+
+        try:
+            runtime.account_ledger.apply(event)
+        except Exception:  # noqa: BLE001 - ledger is a secondary projection; never break trading
+            _log.exception(
+                'account ledger projection failed: account=%s event=%s',
+                runtime.account_id,
+                type(event).__name__,
+            )
+
+    def _bridge_legacy_registration(
+        self,
+        runtime: _AccountRuntime,
+        events: list[tuple[int, Event]],
+    ) -> None:
+        '''Register a pre-feature account's ledger with the FIFO default.
+
+        Spine history written before the Account sub-system carries no
+        `RegisterAccount` event. When such history books ledger events, the
+        strict ledger is registered in memory with the default method so
+        replay can project the fills; the synthetic event is never written
+        back to the spine.
+        '''
+
+        booked = [
+            event for _seq, event in events
+            if isinstance(event, RegisterAccount | FillReceived | TradeClosed)
+        ]
+
+        if booked and not any(isinstance(event, RegisterAccount) for event in booked):
+            runtime.account_ledger.apply(
+                RegisterAccount(
+                    account_id=runtime.account_id,
+                    timestamp=self._clock(),
+                    cost_basis_method=CostBasisMethod.FIFO.value,
+                )
+            )
+
+    async def register_account_on_spine(
+        self,
+        account_id: str,
+        cost_basis_method: CostBasisMethod = CostBasisMethod.FIFO,
+    ) -> None:
+        '''Append a `RegisterAccount` event and project it into the ledger.
+
+        Called for a genuinely new account so its registration is a durable,
+        replayable fact ahead of any booked event. A ledger already
+        registered (from replayed history or the legacy bridge) is left
+        untouched.
+
+        Args:
+            account_id: Account to register on the spine.
+            cost_basis_method: Cost-basis method fixed for the account.
+
+        Raises:
+            AccountNotRegisteredError: If account_id has no runtime.
+        '''
+
+        runtime = self._accounts.get(account_id)
+
+        if runtime is None:
+            msg = f"account_id '{account_id}' is not registered"
+            raise AccountNotRegisteredError(msg)
+
+        if runtime.account_ledger.cost_basis_method is not None:
+            return
+
+        event = RegisterAccount(
+            account_id=account_id,
+            timestamp=self._clock(),
+            cost_basis_method=cost_basis_method.value,
+        )
+        seq = await self._event_spine.append(event, self._epoch_id)
+
+        if seq is not None:
+            self._project(runtime, event)
 
     async def reconcile_orphan_commands(
         self,
@@ -893,7 +999,7 @@ class ExecutionManager:
                 while not runtime.ws_event_queue.empty():
                     event = runtime.ws_event_queue.get_nowait()
                     try:
-                        runtime.trading_state.apply(event)
+                        self._project(runtime, event)
                     except asyncio.CancelledError:
                         raise
                     except Exception:  # noqa: BLE001
@@ -1143,7 +1249,7 @@ class ExecutionManager:
             )
             seq = await self._event_spine.append(fill_event, self._epoch_id)
             if seq is not None:
-                runtime.trading_state.apply(fill_event)
+                self._project(runtime, fill_event)
 
         _log.info(
             'order submitted: client_order_id=%s venue_order_id=%s fills=%d',
@@ -1561,7 +1667,7 @@ class ExecutionManager:
                 command_id=order.command_id,
             )
             await self._event_spine.append(closed, self._epoch_id)
-            runtime.trading_state.apply(closed)
+            self._project(runtime, closed)
 
         produced = TradeOutcomeProduced(
             account_id=order.account_id,
@@ -1751,7 +1857,7 @@ class ExecutionManager:
                     command_id=cmd.command_id,
                 )
                 await self._event_spine.append(closed, self._epoch_id)
-                runtime.trading_state.apply(closed)
+                self._project(runtime, closed)
 
         produced = TradeOutcomeProduced(
             account_id=cmd.account_id,

--- a/praxis/core/execution_manager.py
+++ b/praxis/core/execution_manager.py
@@ -33,6 +33,7 @@ from praxis.core.domain.events import (
     CommandAccepted,
     Event,
     FillReceived,
+    FundTransaction,
     OrderCanceled,
     OrderExpired,
     OrderQuoteNativeFilled,
@@ -419,13 +420,14 @@ class ExecutionManager:
     def _project(self, runtime: _AccountRuntime, event: Event) -> None:
         '''Apply an event to the account's trading-state and ledger projections.
 
-        `RegisterAccount` books into the ledger only; `FillReceived` and
-        `TradeClosed` book into both; every other event advances the trading
-        state alone. The ledger is a secondary projection, so a projection
-        failure is logged and never propagated into the trading path.
+        `RegisterAccount` and `FundTransaction` book into the ledger only;
+        `FillReceived` and `TradeClosed` book into both; every other event
+        advances the trading state alone. The ledger is a secondary
+        projection, so a projection failure is logged and never propagated
+        into the trading path.
         '''
 
-        if isinstance(event, RegisterAccount):
+        if isinstance(event, RegisterAccount | FundTransaction):
             self._project_to_ledger(runtime, event)
 
             return
@@ -462,7 +464,7 @@ class ExecutionManager:
 
         booked = [
             event for _seq, event in events
-            if isinstance(event, RegisterAccount | FillReceived | TradeClosed)
+            if isinstance(event, RegisterAccount | FillReceived | TradeClosed | FundTransaction)
         ]
 
         if booked and not any(isinstance(event, RegisterAccount) for event in booked):

--- a/praxis/infrastructure/event_spine.py
+++ b/praxis/infrastructure/event_spine.py
@@ -43,6 +43,7 @@ from praxis.core.domain.events import (
     OutcomeAcked,
     OutcomeDeliveryContextRecorded,
     OutcomeReplayAbandoned,
+    RegisterAccount,
     TradeClosed,
     TradeOutcomeProduced,
 )
@@ -110,6 +111,7 @@ _EVENT_REGISTRY: dict[str, type] = {
         OutcomeDeliveryContextRecorded,
         OutcomeReplayAbandoned,
         MarkSampled,
+        RegisterAccount,
     )
 }
 

--- a/praxis/infrastructure/event_spine.py
+++ b/praxis/infrastructure/event_spine.py
@@ -31,6 +31,7 @@ from praxis.core.domain.events import (
     CommandAccepted,
     Event,
     FillReceived,
+    FundTransaction,
     MarkSampled,
     OrderAcked,
     OrderCanceled,
@@ -112,6 +113,7 @@ _EVENT_REGISTRY: dict[str, type] = {
         OutcomeReplayAbandoned,
         MarkSampled,
         RegisterAccount,
+        FundTransaction,
     )
 }
 

--- a/praxis/trading.py
+++ b/praxis/trading.py
@@ -331,10 +331,7 @@ class Trading:
         '''
 
         self._execution_manager.replay_events(account_id, account_events)
-
-        if not account_events:
-            await self._execution_manager.register_account_on_spine(account_id)
-
+        await self._execution_manager.register_account_on_spine(account_id)
         await self._execution_manager.reconcile_orphan_commands(
             account_id, account_events,
         )

--- a/praxis/trading.py
+++ b/praxis/trading.py
@@ -331,6 +331,10 @@ class Trading:
         '''
 
         self._execution_manager.replay_events(account_id, account_events)
+
+        if not account_events:
+            await self._execution_manager.register_account_on_spine(account_id)
+
         await self._execution_manager.reconcile_orphan_commands(
             account_id, account_events,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum-praxis"
-version = "0.90.0"
+version = "0.91.0"
 description = "Execution system for Vaquum — Trading sub-system + Account sub-system."
 readme = "README.md"
 authors = [

--- a/tests/test_account_ledger.py
+++ b/tests/test_account_ledger.py
@@ -1,0 +1,157 @@
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+
+from praxis.core.account_ledger import AccountLedger, CostBasisMethod
+from praxis.core.domain.chart_of_accounts import Account, is_debit_normal
+from praxis.core.domain.enums import OrderSide
+from praxis.core.domain.events import FillReceived, TradeClosed
+
+_TS = datetime(2026, 1, 1, tzinfo=UTC)
+
+
+def _fill(side: OrderSide, qty: str, price: str, fee: str, tid: str = 'a',
+          fee_asset: str = 'USDT') -> FillReceived:
+    return FillReceived(
+        account_id='acc', timestamp=_TS, client_order_id=f'c-{side.value}-{qty}-{price}',
+        venue_order_id='v', venue_trade_id='vt', trade_id=tid, command_id='cmd',
+        symbol='BTCUSDT', side=side, qty=Decimal(qty), price=Decimal(price),
+        fee=Decimal(fee), fee_asset=fee_asset, is_maker=False,
+    )
+
+
+def _ledger() -> AccountLedger:
+    return AccountLedger('acc')
+
+
+def test_buy_posts_balanced_entry_and_balances():
+    ledger = _ledger()
+    ledger.apply(_fill(OrderSide.BUY, '1', '100', '0.1'))
+
+    assert len(ledger.journal) == 1
+    assert ledger.balances[Account.CRYPTO_BTC] == Decimal('100')
+    assert ledger.balances[Account.CASH_USDT] == Decimal('-100.1')
+    assert ledger.balances[Account.FEES] == Decimal('0.1')
+    assert ledger.balances[Account.REALIZED_PNL] == Decimal('0')
+
+
+def test_sell_realizes_pnl_against_fifo_cost():
+    ledger = _ledger()
+    ledger.apply(_fill(OrderSide.BUY, '1', '100', '0.1'))
+    ledger.apply(_fill(OrderSide.SELL, '1', '110', '0.11'))
+
+    assert ledger.balances[Account.REALIZED_PNL] == Decimal('10')
+    assert ledger.balances[Account.CRYPTO_BTC] == Decimal('0')
+    assert ledger.balances[Account.FEES] == Decimal('0.21')
+    assert ledger.balances[Account.CASH_USDT] == Decimal('9.79')
+
+
+def test_fifo_consumes_oldest_lots_first():
+    ledger = _ledger()
+    ledger.apply(_fill(OrderSide.BUY, '1', '100', '0'))
+    ledger.apply(_fill(OrderSide.BUY, '1', '110', '0'))
+    ledger.apply(_fill(OrderSide.SELL, '2', '120', '0'))
+
+    assert ledger.balances[Account.REALIZED_PNL] == Decimal('30')
+    assert ledger.balances[Account.CRYPTO_BTC] == Decimal('0')
+    assert ledger.balances[Account.CASH_USDT] == Decimal('30')
+
+
+def test_loss_debits_realized_pnl():
+    ledger = _ledger()
+    ledger.apply(_fill(OrderSide.BUY, '1', '100', '0'))
+    ledger.apply(_fill(OrderSide.SELL, '1', '90', '0'))
+
+    assert ledger.balances[Account.REALIZED_PNL] == Decimal('-10')
+    assert ledger.balances[Account.CASH_USDT] == Decimal('-10')
+
+
+def test_partial_sell_leaves_residual_lot():
+    ledger = _ledger()
+    ledger.apply(_fill(OrderSide.BUY, '3', '100', '0'))
+    ledger.apply(_fill(OrderSide.SELL, '1', '120', '0'))
+
+    assert ledger.balances[Account.REALIZED_PNL] == Decimal('20')
+    assert ledger.balances[Account.CRYPTO_BTC] == Decimal('200')
+
+
+def test_sell_exceeding_lots_raises():
+    ledger = _ledger()
+    ledger.apply(_fill(OrderSide.BUY, '1', '100', '0'))
+
+    with pytest.raises(ValueError, match='sell qty exceeds open lots'):
+        ledger.apply(_fill(OrderSide.SELL, '2', '110', '0'))
+
+
+def test_trade_closed_is_noop():
+    ledger = _ledger()
+    ledger.apply(_fill(OrderSide.BUY, '1', '100', '0.1'))
+    before = dict(ledger.balances)
+    journal_len = len(ledger.journal)
+    ledger.apply(TradeClosed(account_id='acc', timestamp=_TS, trade_id='a', command_id='cmd'))
+
+    assert ledger.balances == before
+    assert len(ledger.journal) == journal_len
+
+
+def test_non_quote_fee_asset_raises():
+    ledger = _ledger()
+
+    with pytest.raises(NotImplementedError, match='not yet supported'):
+        ledger.apply(_fill(OrderSide.BUY, '1', '100', '0.001', fee_asset='BNB'))
+
+
+def test_unsupported_cost_basis_method_rejected():
+    with pytest.raises(ValueError, match='unsupported cost_basis_method'):
+        AccountLedger('acc', cost_basis_method='LIFO')  # type: ignore[arg-type]
+
+
+def test_every_entry_is_balanced_and_balances_reconcile():
+    ledger = _ledger()
+    ledger.apply(_fill(OrderSide.BUY, '2', '100', '0.2'))
+    ledger.apply(_fill(OrderSide.SELL, '1', '130', '0.13'))
+    ledger.apply(_fill(OrderSide.BUY, '1', '105', '0.105', tid='b'))
+    ledger.apply(_fill(OrderSide.SELL, '1', '95', '0.095', tid='b'))
+
+    recomputed = {account: Decimal('0') for account in Account}
+
+    for entry in ledger.journal:
+        assert sum(line.debit for line in entry.lines) == sum(line.credit for line in entry.lines)
+
+        for line in entry.lines:
+            delta = line.debit - line.credit if is_debit_normal(line.account) else line.credit - line.debit
+            recomputed[line.account] += delta
+
+    assert recomputed == ledger.balances
+
+
+def test_default_cost_basis_is_fifo():
+    assert _ledger().cost_basis_method is CostBasisMethod.FIFO
+
+
+def test_average_cost_basis_blends_lot_cost():
+    ledger = AccountLedger('acc', CostBasisMethod.AVERAGE)
+    ledger.apply(_fill(OrderSide.BUY, '1', '100', '0'))
+    ledger.apply(_fill(OrderSide.BUY, '1', '110', '0'))
+    ledger.apply(_fill(OrderSide.SELL, '1', '120', '0'))
+
+    assert ledger.balances[Account.REALIZED_PNL] == Decimal('15')
+    assert ledger.balances[Account.CRYPTO_BTC] == Decimal('105')
+
+
+def test_fifo_and_average_differ_on_partial_exit():
+    sequence = [
+        (OrderSide.BUY, '1', '100'),
+        (OrderSide.BUY, '1', '110'),
+        (OrderSide.SELL, '1', '120'),
+    ]
+    fifo = AccountLedger('acc', CostBasisMethod.FIFO)
+    average = AccountLedger('acc', CostBasisMethod.AVERAGE)
+
+    for side, qty, price in sequence:
+        fifo.apply(_fill(side, qty, price, '0'))
+        average.apply(_fill(side, qty, price, '0'))
+
+    assert fifo.balances[Account.REALIZED_PNL] == Decimal('20')
+    assert average.balances[Account.REALIZED_PNL] == Decimal('15')

--- a/tests/test_account_ledger.py
+++ b/tests/test_account_ledger.py
@@ -399,3 +399,24 @@ def test_fund_transaction_round_trips_through_snapshot():
 
     assert restored.balances[Account.CASH_USDT] == Decimal('1000')
     assert restored.balances[Account.CONTRIBUTIONS] == Decimal('1000')
+
+
+def test_read_balances_returns_a_detached_copy():
+    ledger = _ledger()
+    ledger.apply(_fund(FundDirection.DEPOSIT, '1000'))
+    balances = ledger.read_balances()
+    balances[Account.CASH_USDT] = Decimal('0')
+
+    assert ledger.balances[Account.CASH_USDT] == Decimal('1000')
+    assert ledger.read_balances()[Account.CASH_USDT] == Decimal('1000')
+
+
+def test_read_trade_pnls_returns_detached_copies():
+    ledger = _ledger()
+    ledger.apply(_fill(OrderSide.BUY, '1', '100', '0.1'))
+    ledger.apply(_fill(OrderSide.SELL, '1', '110', '0.11'))
+    pnls = ledger.read_trade_pnls()
+    pnls['a'].realized_gross = Decimal('0')
+
+    assert ledger.trades['a'].realized_gross == Decimal('10')
+    assert ledger.read_trade_pnls()['a'].net == Decimal('9.79')

--- a/tests/test_account_ledger.py
+++ b/tests/test_account_ledger.py
@@ -7,7 +7,7 @@ import pytest
 from praxis.core.account_ledger import AccountLedger, CostBasisMethod
 from praxis.core.domain.chart_of_accounts import Account, is_debit_normal
 from praxis.core.domain.enums import OrderSide
-from praxis.core.domain.events import FillReceived, TradeClosed
+from praxis.core.domain.events import FillReceived, RegisterAccount, TradeClosed
 
 _TS = datetime(2026, 1, 1, tzinfo=UTC)
 
@@ -22,8 +22,15 @@ def _fill(side: OrderSide, qty: str, price: str, fee: str, tid: str = 'a',
     )
 
 
-def _ledger() -> AccountLedger:
-    return AccountLedger('acc')
+def _register(account_id: str = 'acc', method: CostBasisMethod = CostBasisMethod.FIFO) -> RegisterAccount:
+    return RegisterAccount(account_id=account_id, timestamp=_TS, cost_basis_method=method.value)
+
+
+def _ledger(method: CostBasisMethod = CostBasisMethod.FIFO) -> AccountLedger:
+    ledger = AccountLedger('acc')
+    ledger.apply(_register(method=method))
+
+    return ledger
 
 
 def test_buy_posts_balanced_entry_and_balances():
@@ -104,8 +111,8 @@ def test_non_quote_fee_asset_raises():
 
 
 def test_unsupported_cost_basis_method_rejected():
-    with pytest.raises(ValueError, match='unsupported cost_basis_method'):
-        AccountLedger('acc', cost_basis_method='LIFO')  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match='cost_basis_method must be one of'):
+        RegisterAccount(account_id='acc', timestamp=_TS, cost_basis_method='LIFO')
 
 
 def test_every_entry_is_balanced_and_balances_reconcile():
@@ -127,8 +134,46 @@ def test_every_entry_is_balanced_and_balances_reconcile():
     assert recomputed == ledger.balances
 
 
-def test_default_cost_basis_is_fifo():
-    assert _ledger().cost_basis_method is CostBasisMethod.FIFO
+def test_register_account_defaults_to_fifo():
+    ledger = AccountLedger('acc')
+    ledger.apply(RegisterAccount(account_id='acc', timestamp=_TS))
+
+    assert ledger.cost_basis_method is CostBasisMethod.FIFO
+
+
+def test_register_account_sets_average_method():
+    ledger = _ledger(CostBasisMethod.AVERAGE)
+
+    assert ledger.cost_basis_method is CostBasisMethod.AVERAGE
+
+
+def test_re_registration_is_rejected_as_immutable():
+    ledger = _ledger(CostBasisMethod.FIFO)
+
+    with pytest.raises(ValueError, match='already registered'):
+        ledger.apply(_register(method=CostBasisMethod.AVERAGE))
+
+
+def test_fill_before_registration_raises():
+    ledger = AccountLedger('acc')
+
+    with pytest.raises(ValueError, match='not registered'):
+        ledger.apply(_fill(OrderSide.BUY, '1', '100', '0'))
+
+
+def test_trade_closed_before_registration_raises():
+    ledger = AccountLedger('acc')
+
+    with pytest.raises(ValueError, match='not registered'):
+        ledger.apply(TradeClosed(account_id='acc', timestamp=_TS, trade_id='a', command_id='cmd'))
+
+
+def test_snapshot_round_trips_registration():
+    ledger = _ledger(CostBasisMethod.AVERAGE)
+    restored = AccountLedger.from_snapshot(ledger.to_snapshot(1, 1))
+
+    assert restored.cost_basis_method is CostBasisMethod.AVERAGE
+    assert restored.state()['registered'] is True
 
 
 def test_per_trade_pnl_accumulates_gross_and_fees():
@@ -179,7 +224,7 @@ def test_per_trade_realized_matches_realized_pnl_balance_for_single_trade():
 
 
 def test_average_cost_basis_blends_lot_cost():
-    ledger = AccountLedger('acc', CostBasisMethod.AVERAGE)
+    ledger = _ledger(CostBasisMethod.AVERAGE)
     ledger.apply(_fill(OrderSide.BUY, '1', '100', '0'))
     ledger.apply(_fill(OrderSide.BUY, '1', '110', '0'))
     ledger.apply(_fill(OrderSide.SELL, '1', '120', '0'))
@@ -194,8 +239,8 @@ def test_fifo_and_average_differ_on_partial_exit():
         (OrderSide.BUY, '1', '110'),
         (OrderSide.SELL, '1', '120'),
     ]
-    fifo = AccountLedger('acc', CostBasisMethod.FIFO)
-    average = AccountLedger('acc', CostBasisMethod.AVERAGE)
+    fifo = _ledger(CostBasisMethod.FIFO)
+    average = _ledger(CostBasisMethod.AVERAGE)
 
     for side, qty, price in sequence:
         fifo.apply(_fill(side, qty, price, '0'))

--- a/tests/test_account_ledger.py
+++ b/tests/test_account_ledger.py
@@ -455,3 +455,10 @@ def test_concurrent_apply_and_read_never_observe_a_half_applied_event():
 
     assert inconsistent == []
     assert ledger.balances[Account.CASH_USDT] == Decimal('0')
+
+
+def test_event_for_a_different_account_raises():
+    ledger = _ledger()
+
+    with pytest.raises(ValueError, match='routed to the ledger'):
+        ledger.apply(RegisterAccount(account_id='other-acc', timestamp=_TS))

--- a/tests/test_account_ledger.py
+++ b/tests/test_account_ledger.py
@@ -14,11 +14,11 @@ _TS = datetime(2026, 1, 1, tzinfo=UTC)
 
 
 def _fill(side: OrderSide, qty: str, price: str, fee: str, tid: str = 'a',
-          fee_asset: str = 'USDT') -> FillReceived:
+          fee_asset: str = 'USDT', symbol: str = 'BTCUSDT') -> FillReceived:
     return FillReceived(
         account_id='acc', timestamp=_TS, client_order_id=f'c-{side.value}-{qty}-{price}',
         venue_order_id='v', venue_trade_id='vt', trade_id=tid, command_id='cmd',
-        symbol='BTCUSDT', side=side, qty=Decimal(qty), price=Decimal(price),
+        symbol=symbol, side=side, qty=Decimal(qty), price=Decimal(price),
         fee=Decimal(fee), fee_asset=fee_asset, is_maker=False,
     )
 
@@ -462,3 +462,10 @@ def test_event_for_a_different_account_raises():
 
     with pytest.raises(ValueError, match='routed to the ledger'):
         ledger.apply(RegisterAccount(account_id='other-acc', timestamp=_TS))
+
+
+def test_fill_for_unsupported_symbol_raises():
+    ledger = _ledger()
+
+    with pytest.raises(NotImplementedError, match='the ledger books only BTCUSDT'):
+        ledger.apply(_fill(OrderSide.BUY, '1', '100', '0', symbol='ETHUSDT'))

--- a/tests/test_account_ledger.py
+++ b/tests/test_account_ledger.py
@@ -130,6 +130,53 @@ def test_default_cost_basis_is_fifo():
     assert _ledger().cost_basis_method is CostBasisMethod.FIFO
 
 
+def test_per_trade_pnl_accumulates_gross_and_fees():
+    ledger = _ledger()
+    ledger.apply(_fill(OrderSide.BUY, '1', '100', '0.1'))
+    ledger.apply(_fill(OrderSide.SELL, '1', '110', '0.11'))
+    trade = ledger.trades['a']
+
+    assert trade.realized_gross == Decimal('10')
+    assert trade.fees == Decimal('0.21')
+    assert trade.net == Decimal('9.79')
+    assert trade.closed is False
+
+
+def test_per_trade_pnl_is_isolated_by_trade_id():
+    ledger = _ledger()
+    ledger.apply(_fill(OrderSide.BUY, '1', '100', '0', tid='a'))
+    ledger.apply(_fill(OrderSide.SELL, '1', '110', '0', tid='a'))
+    ledger.apply(_fill(OrderSide.BUY, '1', '100', '0', tid='b'))
+    ledger.apply(_fill(OrderSide.SELL, '1', '90', '0', tid='b'))
+
+    assert ledger.trades['a'].realized_gross == Decimal('10')
+    assert ledger.trades['b'].realized_gross == Decimal('-10')
+
+
+def test_trade_closed_marks_trade_closed():
+    ledger = _ledger()
+    ledger.apply(_fill(OrderSide.BUY, '1', '100', '0'))
+    ledger.apply(_fill(OrderSide.SELL, '1', '110', '0'))
+    ledger.apply(TradeClosed(account_id='acc', timestamp=_TS, trade_id='a', command_id='cmd'))
+
+    assert ledger.trades['a'].closed is True
+
+
+def test_trade_closed_for_unknown_trade_is_noop():
+    ledger = _ledger()
+    ledger.apply(TradeClosed(account_id='acc', timestamp=_TS, trade_id='zzz', command_id='cmd'))
+
+    assert ledger.trades == {}
+
+
+def test_per_trade_realized_matches_realized_pnl_balance_for_single_trade():
+    ledger = _ledger()
+    ledger.apply(_fill(OrderSide.BUY, '2', '100', '0'))
+    ledger.apply(_fill(OrderSide.SELL, '2', '130', '0'))
+
+    assert ledger.trades['a'].realized_gross == ledger.balances[Account.REALIZED_PNL]
+
+
 def test_average_cost_basis_blends_lot_cost():
     ledger = AccountLedger('acc', CostBasisMethod.AVERAGE)
     ledger.apply(_fill(OrderSide.BUY, '1', '100', '0'))

--- a/tests/test_account_ledger.py
+++ b/tests/test_account_ledger.py
@@ -432,7 +432,7 @@ def test_base_asset_fee_not_smaller_than_qty_raises():
 
 def test_concurrent_apply_and_read_never_observe_a_half_applied_event():
     ledger = _ledger()
-    inconsistent: list[dict[Account, object]] = []
+    inconsistent: list[dict[Account, Decimal]] = []
 
     def read() -> None:
         for _ in range(500):

--- a/tests/test_account_ledger.py
+++ b/tests/test_account_ledger.py
@@ -1,3 +1,4 @@
+import json
 from datetime import UTC, datetime
 from decimal import Decimal
 
@@ -202,3 +203,62 @@ def test_fifo_and_average_differ_on_partial_exit():
 
     assert fifo.balances[Account.REALIZED_PNL] == Decimal('20')
     assert average.balances[Account.REALIZED_PNL] == Decimal('15')
+
+
+def test_snapshot_round_trip_preserves_state():
+    ledger = _ledger()
+    ledger.apply(_fill(OrderSide.BUY, '2', '100', '0.2'))
+    ledger.apply(_fill(OrderSide.SELL, '1', '130', '0.13'))
+    snapshot = ledger.to_snapshot(last_applied_event_seq=7, epoch_id=3)
+    restored = AccountLedger.from_snapshot(snapshot)
+
+    assert snapshot['last_applied_event_seq'] == 7
+    assert snapshot['epoch_id'] == 3
+    assert restored.state() == ledger.state()
+
+
+def test_replay_reproduces_live_state():
+    events = [
+        _fill(OrderSide.BUY, '2', '100', '0.2'),
+        _fill(OrderSide.SELL, '1', '130', '0.13'),
+        _fill(OrderSide.BUY, '1', '105', '0', tid='b'),
+        TradeClosed(account_id='acc', timestamp=_TS, trade_id='b', command_id='cmd'),
+    ]
+    live = _ledger()
+    replayed = _ledger()
+
+    for event in events:
+        live.apply(event)
+
+    for event in events:
+        replayed.apply(event)
+
+    assert replayed.state() == live.state()
+
+
+def test_restored_ledger_realizes_against_restored_lots():
+    ledger = _ledger()
+    ledger.apply(_fill(OrderSide.BUY, '1', '100', '0'))
+    restored = AccountLedger.from_snapshot(ledger.to_snapshot(1, 1))
+    restored.apply(_fill(OrderSide.SELL, '1', '110', '0'))
+
+    assert restored.trades['a'].realized_gross == Decimal('10')
+    assert restored.balances[Account.REALIZED_PNL] == Decimal('10')
+
+
+def test_snapshot_does_not_restore_journal():
+    ledger = _ledger()
+    ledger.apply(_fill(OrderSide.BUY, '1', '100', '0.1'))
+    restored = AccountLedger.from_snapshot(ledger.to_snapshot(1, 1))
+
+    assert restored.journal == []
+    assert restored.balances[Account.CRYPTO_BTC] == Decimal('100')
+
+
+def test_snapshot_is_json_serialisable():
+    ledger = _ledger()
+    ledger.apply(_fill(OrderSide.BUY, '1', '100', '0.1'))
+    ledger.apply(_fill(OrderSide.SELL, '1', '110', '0.11'))
+    snapshot = ledger.to_snapshot(2, 1)
+
+    assert json.loads(json.dumps(snapshot)) == snapshot

--- a/tests/test_account_ledger.py
+++ b/tests/test_account_ledger.py
@@ -1,4 +1,5 @@
 import json
+import threading
 from datetime import UTC, datetime
 from decimal import Decimal
 
@@ -427,3 +428,30 @@ def test_base_asset_fee_not_smaller_than_qty_raises():
 
     with pytest.raises(ValueError, match='must be smaller than the filled qty'):
         ledger.apply(_fill(OrderSide.BUY, '1', '100', '1', fee_asset='BTC'))
+
+
+def test_concurrent_apply_and_read_never_observe_a_half_applied_event():
+    ledger = _ledger()
+    inconsistent: list[dict[Account, object]] = []
+
+    def read() -> None:
+        for _ in range(500):
+            balances = ledger.read_balances()
+
+            if balances[Account.CASH_USDT] != balances[Account.CONTRIBUTIONS]:
+                inconsistent.append(balances)
+
+    def write() -> None:
+        for index in range(500):
+            ledger.apply(_fund(FundDirection.DEPOSIT, '1', tx=f'd{index}'))
+            ledger.apply(_fund(FundDirection.WITHDRAWAL, '1', tx=f'w{index}'))
+
+    reader = threading.Thread(target=read)
+    writer = threading.Thread(target=write)
+    reader.start()
+    writer.start()
+    reader.join()
+    writer.join()
+
+    assert inconsistent == []
+    assert ledger.balances[Account.CASH_USDT] == Decimal('0')

--- a/tests/test_account_ledger.py
+++ b/tests/test_account_ledger.py
@@ -420,3 +420,10 @@ def test_read_trade_pnls_returns_detached_copies():
 
     assert ledger.trades['a'].realized_gross == Decimal('10')
     assert ledger.read_trade_pnls()['a'].net == Decimal('9.79')
+
+
+def test_base_asset_fee_not_smaller_than_qty_raises():
+    ledger = _ledger()
+
+    with pytest.raises(ValueError, match='must be smaller than the filled qty'):
+        ledger.apply(_fill(OrderSide.BUY, '1', '100', '1', fee_asset='BTC'))

--- a/tests/test_account_ledger.py
+++ b/tests/test_account_ledger.py
@@ -103,11 +103,46 @@ def test_trade_closed_is_noop():
     assert len(ledger.journal) == journal_len
 
 
-def test_non_quote_fee_asset_raises():
+def test_third_asset_fee_on_buy_raises():
     ledger = _ledger()
 
-    with pytest.raises(NotImplementedError, match='not yet supported'):
+    with pytest.raises(NotImplementedError, match='not supported for a buy fill'):
         ledger.apply(_fill(OrderSide.BUY, '1', '100', '0.001', fee_asset='BNB'))
+
+
+def test_third_asset_fee_on_sell_raises():
+    ledger = _ledger()
+    ledger.apply(_fill(OrderSide.BUY, '1', '100', '0'))
+
+    with pytest.raises(NotImplementedError, match='not supported for a sell fill'):
+        ledger.apply(_fill(OrderSide.SELL, '1', '110', '0.001', fee_asset='BNB'))
+
+
+def test_base_asset_fee_on_buy_expenses_value_and_reduces_position():
+    ledger = _ledger()
+    ledger.apply(_fill(OrderSide.BUY, '1', '100', '0.001', fee_asset='BTC'))
+
+    assert ledger.balances[Account.CASH_USDT] == Decimal('-100')
+    assert ledger.balances[Account.FEES] == Decimal('0.1')
+    assert ledger.balances[Account.CRYPTO_BTC] == Decimal('99.9')
+    assert ledger.trades['a'].fees == Decimal('0.1')
+
+
+def test_base_asset_fee_lot_is_net_received():
+    ledger = _ledger()
+    ledger.apply(_fill(OrderSide.BUY, '1', '100', '0.001', fee_asset='BTC'))
+    ledger.apply(_fill(OrderSide.SELL, '0.999', '110', '0'))
+
+    assert ledger.balances[Account.CRYPTO_BTC] == Decimal('0')
+    assert ledger.balances[Account.REALIZED_PNL] == Decimal('9.99')
+
+
+def test_base_asset_fee_sell_exceeding_net_lot_raises():
+    ledger = _ledger()
+    ledger.apply(_fill(OrderSide.BUY, '1', '100', '0.001', fee_asset='BTC'))
+
+    with pytest.raises(ValueError, match='sell qty exceeds open lots'):
+        ledger.apply(_fill(OrderSide.SELL, '1', '110', '0'))
 
 
 def test_unsupported_cost_basis_method_rejected():

--- a/tests/test_account_ledger.py
+++ b/tests/test_account_ledger.py
@@ -6,8 +6,8 @@ import pytest
 
 from praxis.core.account_ledger import AccountLedger, CostBasisMethod
 from praxis.core.domain.chart_of_accounts import Account, is_debit_normal
-from praxis.core.domain.enums import OrderSide
-from praxis.core.domain.events import FillReceived, RegisterAccount, TradeClosed
+from praxis.core.domain.enums import FundDirection, OrderSide
+from praxis.core.domain.events import FillReceived, FundTransaction, RegisterAccount, TradeClosed
 
 _TS = datetime(2026, 1, 1, tzinfo=UTC)
 
@@ -342,3 +342,60 @@ def test_snapshot_is_json_serialisable():
     snapshot = ledger.to_snapshot(2, 1)
 
     assert json.loads(json.dumps(snapshot)) == snapshot
+
+
+def _fund(direction: FundDirection, amount: str, tx: str = 'f-1') -> FundTransaction:
+    return FundTransaction(
+        account_id='acc', timestamp=_TS, fund_transaction_id=tx,
+        amount=Decimal(amount), direction=direction.value,
+    )
+
+
+def test_deposit_credits_contributions_and_cash():
+    ledger = _ledger()
+    ledger.apply(_fund(FundDirection.DEPOSIT, '1000'))
+
+    assert ledger.balances[Account.CASH_USDT] == Decimal('1000')
+    assert ledger.balances[Account.CONTRIBUTIONS] == Decimal('1000')
+
+
+def test_withdrawal_debits_contributions_and_cash():
+    ledger = _ledger()
+    ledger.apply(_fund(FundDirection.DEPOSIT, '1000'))
+    ledger.apply(_fund(FundDirection.WITHDRAWAL, '300', tx='f-2'))
+
+    assert ledger.balances[Account.CASH_USDT] == Decimal('700')
+    assert ledger.balances[Account.CONTRIBUTIONS] == Decimal('700')
+
+
+def test_over_withdrawal_is_recorded_not_rejected():
+    ledger = _ledger()
+    ledger.apply(_fund(FundDirection.WITHDRAWAL, '500'))
+
+    assert ledger.balances[Account.CASH_USDT] == Decimal('-500')
+    assert ledger.balances[Account.CONTRIBUTIONS] == Decimal('-500')
+
+
+def test_fund_transaction_does_not_create_a_trade():
+    ledger = _ledger()
+    ledger.apply(_fund(FundDirection.DEPOSIT, '1000'))
+
+    assert ledger.trades == {}
+    assert len(ledger.journal) == 1
+    assert ledger.journal[0].source_event_type == 'FundTransaction'
+
+
+def test_fund_transaction_before_registration_raises():
+    ledger = AccountLedger('acc')
+
+    with pytest.raises(ValueError, match='not registered'):
+        ledger.apply(_fund(FundDirection.DEPOSIT, '1000'))
+
+
+def test_fund_transaction_round_trips_through_snapshot():
+    ledger = _ledger()
+    ledger.apply(_fund(FundDirection.DEPOSIT, '1000'))
+    restored = AccountLedger.from_snapshot(ledger.to_snapshot(1, 1))
+
+    assert restored.balances[Account.CASH_USDT] == Decimal('1000')
+    assert restored.balances[Account.CONTRIBUTIONS] == Decimal('1000')

--- a/tests/test_event_spine.py
+++ b/tests/test_event_spine.py
@@ -19,6 +19,7 @@ from praxis.core.domain.events import (
     CommandAccepted,
     Event,
     FillReceived,
+    FundTransaction,
     MarkSampled,
     OrderAcked,
     OrderCanceled,
@@ -110,6 +111,10 @@ _ALL_EVENTS: list[Event] = [
     RegisterAccount(
         account_id=_ACCT, timestamp=_TS,
         cost_basis_method='AVERAGE',
+    ),
+    FundTransaction(
+        account_id=_ACCT, timestamp=_TS,
+        fund_transaction_id='fund-1', amount=Decimal('1000'), direction='DEPOSIT',
     ),
 
 ]

--- a/tests/test_event_spine.py
+++ b/tests/test_event_spine.py
@@ -27,6 +27,7 @@ from praxis.core.domain.events import (
     OrderSubmitFailed,
     OrderSubmitIntent,
     OrderSubmitted,
+    RegisterAccount,
     TradeClosed,
 )
 from praxis.infrastructure.event_spine import EventSpine
@@ -105,6 +106,10 @@ _ALL_EVENTS: list[Event] = [
     MarkSampled(
         account_id=_ACCT, timestamp=_TS,
         symbol=_SYMBOL, mark_price=Decimal('62000.5'),
+    ),
+    RegisterAccount(
+        account_id=_ACCT, timestamp=_TS,
+        cost_basis_method='AVERAGE',
     ),
 
 ]

--- a/tests/test_execution_manager.py
+++ b/tests/test_execution_manager.py
@@ -33,8 +33,11 @@ from praxis.core.domain.events import (
     OrderRejected,
     OrderSubmitIntent,
     OrderSubmitted,
+    RegisterAccount,
     TradeOutcomeProduced,
 )
+from praxis.core.account_ledger import CostBasisMethod
+from praxis.core.domain.chart_of_accounts import Account
 from praxis.core.domain.single_shot_params import SingleShotParams
 from praxis.core.domain.trade_abort import TradeAbort
 from praxis.core.domain.trade_outcome import TradeOutcome
@@ -2667,3 +2670,75 @@ class TestQuiesce:
         mgr: ExecutionManager,
     ) -> None:
         await mgr.quiesce('unregistered')
+
+
+class TestAccountLedgerWiring:
+    '''AccountLedger projection wired into the per-account spine-append path.'''
+
+    def _fill(self, fee_asset: str = 'USDT') -> FillReceived:
+        return FillReceived(
+            account_id=_ACCT, timestamp=_TS, client_order_id='c-1',
+            venue_order_id='v-1', venue_trade_id='vt-1', trade_id=_TRADE, command_id='cmd-1',
+            symbol='BTCUSDT', side=OrderSide.BUY, qty=Decimal('1'), price=Decimal('100'),
+            fee=Decimal('0.1'), fee_asset=fee_asset, is_maker=False,
+        )
+
+    @pytest.mark.asyncio
+    async def test_replay_legacy_history_default_registers_and_books(
+        self, mgr: ExecutionManager,
+    ) -> None:
+        mgr.register_account(_ACCT)
+        mgr.replay_events(_ACCT, [(1, self._fill())])
+        ledger = mgr._accounts[_ACCT].account_ledger
+
+        assert ledger.cost_basis_method is CostBasisMethod.FIFO
+        assert ledger.balances[Account.CRYPTO_BTC] == Decimal('100')
+
+    @pytest.mark.asyncio
+    async def test_replay_honors_registered_cost_basis_method(
+        self, mgr: ExecutionManager,
+    ) -> None:
+        mgr.register_account(_ACCT)
+        mgr.replay_events(_ACCT, [
+            (1, RegisterAccount(account_id=_ACCT, timestamp=_TS, cost_basis_method='AVERAGE')),
+            (2, self._fill()),
+        ])
+        ledger = mgr._accounts[_ACCT].account_ledger
+
+        assert ledger.cost_basis_method is CostBasisMethod.AVERAGE
+        assert ledger.balances[Account.CRYPTO_BTC] == Decimal('100')
+
+    @pytest.mark.asyncio
+    async def test_ledger_projection_failure_is_isolated(
+        self, mgr: ExecutionManager,
+    ) -> None:
+        mgr.register_account(_ACCT)
+        mgr.replay_events(_ACCT, [(1, self._fill(fee_asset='BNB'))])
+        runtime = mgr._accounts[_ACCT]
+
+        assert (_TRADE, _ACCT) in mgr.pull_positions(_ACCT)
+        assert runtime.account_ledger.balances[Account.CRYPTO_BTC] == Decimal('0')
+
+    @pytest.mark.asyncio
+    async def test_new_account_registration_appends_and_registers(
+        self, mgr: ExecutionManager, spine: EventSpine,
+    ) -> None:
+        mgr.register_account(_ACCT)
+        await mgr.register_account_on_spine(_ACCT)
+        events = await spine.read(_EPOCH)
+        ledger = mgr._accounts[_ACCT].account_ledger
+
+        assert any(isinstance(event, RegisterAccount) for _seq, event in events)
+        assert ledger.cost_basis_method is CostBasisMethod.FIFO
+
+    @pytest.mark.asyncio
+    async def test_register_account_on_spine_is_idempotent(
+        self, mgr: ExecutionManager, spine: EventSpine,
+    ) -> None:
+        mgr.register_account(_ACCT)
+        await mgr.register_account_on_spine(_ACCT)
+        await mgr.register_account_on_spine(_ACCT)
+        events = await spine.read(_EPOCH)
+
+        registrations = [event for _seq, event in events if isinstance(event, RegisterAccount)]
+        assert len(registrations) == 1

--- a/tests/test_execution_manager.py
+++ b/tests/test_execution_manager.py
@@ -2760,3 +2760,29 @@ class TestAccountLedgerWiring:
 
         assert ledger.balances[Account.CASH_USDT] == Decimal('1000')
         assert ledger.balances[Account.CONTRIBUTIONS] == Decimal('1000')
+
+    @pytest.mark.asyncio
+    async def test_read_interface_returns_balances_and_trade_pnls(
+        self, mgr: ExecutionManager,
+    ) -> None:
+        mgr.register_account(_ACCT)
+        mgr.replay_events(_ACCT, [
+            (1, RegisterAccount(account_id=_ACCT, timestamp=_TS, cost_basis_method='FIFO')),
+            (2, self._fill()),
+        ])
+
+        balances = mgr.get_account_balances(_ACCT)
+        pnls = mgr.get_account_trade_pnls(_ACCT)
+
+        assert balances[Account.CRYPTO_BTC] == Decimal('100')
+        assert pnls[_TRADE].fees == Decimal('0.1')
+
+    @pytest.mark.asyncio
+    async def test_read_interface_raises_for_unknown_account(
+        self, mgr: ExecutionManager,
+    ) -> None:
+        with pytest.raises(AccountNotRegisteredError):
+            mgr.get_account_balances('nope')
+
+        with pytest.raises(AccountNotRegisteredError):
+            mgr.get_account_trade_pnls('nope')

--- a/tests/test_execution_manager.py
+++ b/tests/test_execution_manager.py
@@ -28,6 +28,7 @@ from praxis.core.domain.enums import (
 from praxis.core.domain.events import (
     CommandAccepted,
     FillReceived,
+    FundTransaction,
     OrderCanceled,
     OrderExpired,
     OrderRejected,
@@ -2742,3 +2743,20 @@ class TestAccountLedgerWiring:
 
         registrations = [event for _seq, event in events if isinstance(event, RegisterAccount)]
         assert len(registrations) == 1
+
+    @pytest.mark.asyncio
+    async def test_replay_books_fund_transaction(
+        self, mgr: ExecutionManager,
+    ) -> None:
+        mgr.register_account(_ACCT)
+        mgr.replay_events(_ACCT, [
+            (1, RegisterAccount(account_id=_ACCT, timestamp=_TS, cost_basis_method='FIFO')),
+            (2, FundTransaction(
+                account_id=_ACCT, timestamp=_TS, fund_transaction_id='f-1',
+                amount=Decimal('1000'), direction='DEPOSIT',
+            )),
+        ])
+        ledger = mgr._accounts[_ACCT].account_ledger
+
+        assert ledger.balances[Account.CASH_USDT] == Decimal('1000')
+        assert ledger.balances[Account.CONTRIBUTIONS] == Decimal('1000')

--- a/tests/test_journal_entry.py
+++ b/tests/test_journal_entry.py
@@ -46,3 +46,15 @@ def test_negative_line_is_rejected():
 def test_empty_entry_is_rejected():
     with pytest.raises(ValueError, match='at least one line'):
         _entry([])
+
+
+def test_naive_timestamp_is_rejected():
+    with pytest.raises(ValueError, match='timezone-aware'):
+        JournalEntry(
+            timestamp=datetime(2026, 1, 1), source_event_type='FillReceived',
+            source_event_id='vt-1', memo='m',
+            lines=(
+                JournalLine(Account.CASH_USDT, Decimal('1'), Decimal('0')),
+                JournalLine(Account.CRYPTO_BTC, Decimal('0'), Decimal('1')),
+            ),
+        )

--- a/tests/test_journal_entry.py
+++ b/tests/test_journal_entry.py
@@ -10,7 +10,10 @@ _TS = datetime(2026, 1, 1, tzinfo=UTC)
 
 
 def _entry(lines: list[JournalLine]) -> JournalEntry:
-    return JournalEntry(timestamp=_TS, trade_id='a', command_id='cmd', memo='m', lines=tuple(lines))
+    return JournalEntry(
+        timestamp=_TS, source_event_type='FillReceived', source_event_id='vt-1',
+        memo='m', lines=tuple(lines),
+    )
 
 
 def test_balanced_entry_is_accepted():

--- a/tests/test_journal_entry.py
+++ b/tests/test_journal_entry.py
@@ -1,0 +1,45 @@
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+
+from praxis.core.domain.chart_of_accounts import Account
+from praxis.core.domain.journal_entry import JournalEntry, JournalLine
+
+_TS = datetime(2026, 1, 1, tzinfo=UTC)
+
+
+def _entry(lines: list[JournalLine]) -> JournalEntry:
+    return JournalEntry(timestamp=_TS, trade_id='a', command_id='cmd', memo='m', lines=tuple(lines))
+
+
+def test_balanced_entry_is_accepted():
+    entry = _entry([
+        JournalLine(Account.CRYPTO_BTC, Decimal('100'), Decimal('0')),
+        JournalLine(Account.CASH_USDT, Decimal('0'), Decimal('100')),
+    ])
+
+    assert len(entry.lines) == 2
+
+
+def test_unbalanced_entry_is_rejected():
+    with pytest.raises(ValueError, match='not balanced'):
+        _entry([
+            JournalLine(Account.CRYPTO_BTC, Decimal('100'), Decimal('0')),
+            JournalLine(Account.CASH_USDT, Decimal('0'), Decimal('99')),
+        ])
+
+
+def test_two_sided_line_is_rejected():
+    with pytest.raises(ValueError, match='one-sided'):
+        JournalLine(Account.CASH_USDT, Decimal('5'), Decimal('5'))
+
+
+def test_negative_line_is_rejected():
+    with pytest.raises(ValueError, match='non-negative'):
+        JournalLine(Account.CASH_USDT, Decimal('-1'), Decimal('0'))
+
+
+def test_empty_entry_is_rejected():
+    with pytest.raises(ValueError, match='at least one line'):
+        _entry([])

--- a/tests/test_trading.py
+++ b/tests/test_trading.py
@@ -30,6 +30,7 @@ from praxis.core.domain.trade_outcome import TradeOutcome
 from praxis.core.domain.events import (
     CommandAccepted,
     FillReceived,
+    MarkSampled,
     OrderCanceled,
     OrderExpired,
     OrderRejected,
@@ -38,6 +39,7 @@ from praxis.core.domain.events import (
     RegisterAccount,
     TradeOutcomeProduced,
 )
+from praxis.core.account_ledger import CostBasisMethod
 from praxis.core.execution_manager import ExecutionManager
 from praxis.infrastructure.binance_adapter import BinanceAdapter
 from praxis.infrastructure.binance_urls import (
@@ -2515,3 +2517,23 @@ async def test_boot_sweep_keeps_locally_known_open_order(spine: EventSpine) -> N
 
     assert adapter.cancelled == []
     assert 'acc-1' in trading._ready_accounts
+
+
+@pytest.mark.asyncio
+async def test_start_registers_account_with_only_non_booking_history(spine: EventSpine) -> None:
+    await spine.append(MarkSampled(
+        account_id='acc-1', timestamp=_CREATED_AT, symbol='BTCUSDT', mark_price=Decimal('50000'),
+    ), 1)
+
+    adapter = cast(VenueAdapter, _InjectedVenueAdapter())
+    trading = Trading(
+        config=TradingConfig(epoch_id=1, account_credentials={'acc-1': ('key', 'secret')}),
+        event_spine=spine,
+        venue_adapter=adapter,
+    )
+    await trading.start()
+
+    ledger = trading.execution_manager._accounts['acc-1'].account_ledger
+    assert ledger.cost_basis_method is CostBasisMethod.FIFO
+
+    await trading.stop()

--- a/tests/test_trading.py
+++ b/tests/test_trading.py
@@ -29,6 +29,7 @@ from praxis.core.domain.trade_abort import TradeAbort
 from praxis.core.domain.trade_outcome import TradeOutcome
 from praxis.core.domain.events import (
     CommandAccepted,
+    Event,
     FillReceived,
     MarkSampled,
     OrderCanceled,
@@ -68,7 +69,7 @@ from praxis.trading_inbound import TradingInbound
 _CREATED_AT = datetime(2099, 1, 1, tzinfo=UTC)
 
 
-async def _trading_events(spine: EventSpine) -> list[tuple[int, object]]:
+async def _trading_events(spine: EventSpine) -> list[tuple[int, Event]]:
     '''Return epoch-1 spine events excluding the per-account `RegisterAccount`.
 
     A new account now durably registers on the spine at startup; these tests

--- a/tests/test_trading.py
+++ b/tests/test_trading.py
@@ -35,6 +35,7 @@ from praxis.core.domain.events import (
     OrderRejected,
     OrderSubmitIntent,
     OrderSubmitted,
+    RegisterAccount,
     TradeOutcomeProduced,
 )
 from praxis.core.execution_manager import ExecutionManager
@@ -63,6 +64,17 @@ from praxis.trading_config import TradingConfig
 from praxis.trading_inbound import TradingInbound
 
 _CREATED_AT = datetime(2099, 1, 1, tzinfo=UTC)
+
+
+async def _trading_events(spine: EventSpine) -> list[tuple[int, object]]:
+    '''Return epoch-1 spine events excluding the per-account `RegisterAccount`.
+
+    A new account now durably registers on the spine at startup; these tests
+    assert on the trading events only.
+    '''
+
+    return [(seq, event) for seq, event in await spine.read(1)
+            if not isinstance(event, RegisterAccount)]
 
 
 class _InjectedVenueAdapter:
@@ -1075,7 +1087,7 @@ async def test_reconcile_account_skips_terminal_orders(spine: EventSpine) -> Non
 
     await trading._reconcile_account('acc-1')
 
-    events = await spine.read(1)
+    events = await _trading_events(spine)
     assert len(events) == 0
     await trading.stop()
 
@@ -1088,7 +1100,7 @@ async def test_reconcile_account_handles_not_found(spine: EventSpine) -> None:
 
     await trading._reconcile_account('acc-1')
 
-    events = await spine.read(1)
+    events = await _trading_events(spine)
     assert len(events) == 0
     await trading.stop()
 
@@ -1130,7 +1142,7 @@ async def test_reconcile_account_reconciles_fills_when_venue_has_more(
     await trading._reconcile_account('acc-1')
     await asyncio.sleep(0.15)
 
-    events = await spine.read(1)
+    events = await _trading_events(spine)
     assert len(events) == 1
     _, event = events[0]
     assert isinstance(event, FillReceived)
@@ -1163,7 +1175,7 @@ async def test_reconcile_account_emits_terminal_when_venue_is_terminal(
 
     await trading._reconcile_account('acc-1')
 
-    events = await spine.read(1)
+    events = await _trading_events(spine)
     assert len(events) == 1
     _, event = events[0]
     assert isinstance(event, OrderCanceled)
@@ -1194,11 +1206,11 @@ async def test_reconcile_fills_deduplicates(spine: EventSpine) -> None:
     adapter._venue_trades = [trade]
 
     await trading._reconcile_fills('acc-1', order)
-    events_after_first = await spine.read(1)
+    events_after_first = await _trading_events(spine)
     assert len(events_after_first) == 1
 
     await trading._reconcile_fills('acc-1', order)
-    events_after_second = await spine.read(1)
+    events_after_second = await _trading_events(spine)
     assert len(events_after_second) == 1
     await trading.stop()
 
@@ -1210,7 +1222,7 @@ async def test_reconcile_fills_skips_unknown_account(spine: EventSpine) -> None:
     order = _make_order()
     await trading._reconcile_fills('unknown-acc', order)
 
-    events = await spine.read(1)
+    events = await _trading_events(spine)
     assert len(events) == 0
     await trading.stop()
 
@@ -1234,7 +1246,7 @@ async def test_reconcile_fills_handles_venue_error(spine: EventSpine) -> None:
 
     await trading._reconcile_fills('acc-1', order)
 
-    events = await spine.read(1)
+    events = await _trading_events(spine)
     assert len(events) == 0
     await trading.stop()
 
@@ -1264,7 +1276,7 @@ async def test_reconcile_fills_skips_mismatched_client_order_id(
 
     await trading._reconcile_fills('acc-1', order)
 
-    events = await spine.read(1)
+    events = await _trading_events(spine)
     assert len(events) == 0
     await trading.stop()
 
@@ -1293,7 +1305,7 @@ async def test_reconcile_fills_skips_missing_trade_id_mapping(
 
     await trading._reconcile_fills('acc-1', order)
 
-    events = await spine.read(1)
+    events = await _trading_events(spine)
     assert len(events) == 0
     await trading.stop()
 
@@ -1316,7 +1328,7 @@ async def test_reconcile_terminal_emits_canceled(spine: EventSpine) -> None:
 
     await trading._reconcile_terminal('acc-1', order, venue_order)
 
-    events = await spine.read(1)
+    events = await _trading_events(spine)
     assert len(events) == 1
     _, event = events[0]
     assert isinstance(event, OrderCanceled)
@@ -1341,7 +1353,7 @@ async def test_reconcile_terminal_emits_expired(spine: EventSpine) -> None:
 
     await trading._reconcile_terminal('acc-1', order, venue_order)
 
-    events = await spine.read(1)
+    events = await _trading_events(spine)
     assert len(events) == 1
     _, event = events[0]
     assert isinstance(event, OrderExpired)
@@ -1366,7 +1378,7 @@ async def test_reconcile_terminal_emits_rejected(spine: EventSpine) -> None:
 
     await trading._reconcile_terminal('acc-1', order, venue_order)
 
-    events = await spine.read(1)
+    events = await _trading_events(spine)
     assert len(events) == 1
     _, event = events[0]
     assert isinstance(event, OrderRejected)
@@ -1393,7 +1405,7 @@ async def test_reconcile_terminal_skips_non_terminal_venue_status(
 
     await trading._reconcile_terminal('acc-1', order, venue_order)
 
-    events = await spine.read(1)
+    events = await _trading_events(spine)
     assert len(events) == 0
     await trading.stop()
 
@@ -1406,7 +1418,7 @@ async def test_on_execution_report_ignores_non_execution_report(
 
     await trading._on_execution_report('acc-1', {'e': 'outboundAccountPosition'})
 
-    events = await spine.read(1)
+    events = await _trading_events(spine)
     assert len(events) == 0
     await trading.stop()
 
@@ -1419,7 +1431,7 @@ async def test_on_execution_report_ignores_non_binance_adapter(
 
     await trading._on_execution_report('acc-1', {'e': 'executionReport'})
 
-    events = await spine.read(1)
+    events = await _trading_events(spine)
     assert len(events) == 0
     await trading.stop()
 
@@ -1434,7 +1446,7 @@ async def test_on_execution_report_skips_unknown_account(
 
     await trading._on_execution_report('unknown-acc', {'e': 'executionReport'})
 
-    events = await spine.read(1)
+    events = await _trading_events(spine)
     assert len(events) == 0
     await trading.stop()
 
@@ -1477,7 +1489,7 @@ async def test_on_execution_report_processes_fill(spine: EventSpine) -> None:
     await trading._on_execution_report('acc-1', {'e': 'executionReport'})
     await asyncio.sleep(0.15)
 
-    events = await spine.read(1)
+    events = await _trading_events(spine)
     assert len(events) == 1
     _, event = events[0]
     assert isinstance(event, FillReceived)
@@ -1527,7 +1539,7 @@ async def test_on_execution_report_skips_terminal_for_closed_order(
 
     await trading._on_execution_report('acc-1', {'e': 'executionReport'})
 
-    events = await spine.read(1)
+    events = await _trading_events(spine)
     assert len(events) == 0
     await trading.stop()
 


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others.

Closes #6 — WP-Praxis-0006: the Account sub-system (the Praxis double-entry ledger, the authoritative books, distinct from Nexus which owns capital + PnL for decisions).

## What does this PR change?

Builds the Account sub-system on top of the existing double-entry `AccountLedger` projection (10.1–10.3):

### Registration & wiring
- Adds a `RegisterAccount` spine event fixing each account's **immutable** `cost_basis_method` (FIFO default). The ledger is **strict**: a fill or trade-closed before registration is rejected, and re-registration raises.
- Wires `AccountLedger.apply` into the per-account spine-append path via a single `_project` helper, at replay and the live fill/trade-closed sites. The ledger is a **secondary projection** — a booking failure is logged and never breaks the trading path. New accounts durably emit `RegisterAccount` at startup; pre-feature spine history (no `RegisterAccount`) is registered in memory with the FIFO default at replay and never written back.

### Booking
- **Base-asset fees:** a `BTC` fee on a buy is valued at the fill price, credits `Crypto:BTC` rather than `Cash:USDT`, and reduces the cost-basis lot to the **net** quantity received, so base inventory and cost basis match the venue balance. A fee ≥ qty is rejected. Quote (`USDT`) fees unchanged; any other fee asset raises.
- **Fund transactions:** a `FundTransaction` event (deposit/withdrawal, with a stable `fund_transaction_id`) books a deposit as `Dr Cash:USDT / Cr Equity:Contributions` and a withdrawal as the reverse; an over-withdrawal is recorded rather than rejected (enforcement belongs upstream).

### Read interface
- `read_balances` / `read_trade_pnls` on `AccountLedger` and `get_account_balances` / `get_account_trade_pnls` on `ExecutionManager`, returning detached copies so a caller cannot mutate the projection.

### Internal
- `JournalEntry` moves from trade-specific `trade_id`/`command_id` to generic `source_event_type`/`source_event_id` (each entry derives from one spine event); `CostBasisMethod` moves to the shared `enums` module.

## Tests

Full suite **1807 passed**; `ruff` full-tree and `mypy` clean. Bumps 0.90.0 → 0.91.0. Two design forks (fee-asset, fund-transactions) were reviewed with a read-only Codex pass. Records **TD-107** (ledger projection failures are swallowed) and **TD-108** (no spine dedup on `fund_transaction_id`) as deferred follow-ups.

## Checklist

- [x] I have reviewed full diff in “Files changed”
- [x] I left no unnecessary files in the changes
- [x] I ran `python tests/run.py` locally without errors (where applicable)
- [ ] I updated `/docs` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md (unless only docs or other non-code aspect was changed)
- [x] I updated pyproject.toml (unless only docs or other non-code aspect was changed)
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [x] I linked issue to auto-close on merge (e.g., “Fixes #123”) when applicable