### PR TITLE
feat: WP-Praxis-0008 — live operability & safety (caps, /ops, price/slippage gates, alerts)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1271,3 +1271,23 @@
 - Add base-asset fee handling: a `BTC` fee on a buy is valued at the fill price, credits `Crypto:BTC` rather than `Cash:USDT`, and reduces the cost-basis lot to the net quantity received, so the ledger's base inventory and cost basis match the venue balance. Quote-asset (`USDT`) fees are unchanged; any other fee asset raises
 - Add a [`FundTransaction`](praxis/core/domain/events.py) spine event (`amount`, a `FundDirection` of `DEPOSIT` or `WITHDRAWAL`, and a stable `fund_transaction_id`) booking a deposit as `Dr Cash:USDT / Cr Equity:Contributions` and a withdrawal as the reverse; the ledger records an over-withdrawal rather than rejecting it, since enforcement belongs upstream
 - Add balances and per-trade realized-P&L read accessors — `read_balances`/`read_trade_pnls` on [`AccountLedger`](praxis/core/account_ledger.py) and `get_account_balances`/`get_account_trade_pnls` on [`ExecutionManager`](praxis/core/execution_manager.py) — returning detached copies so a caller cannot mutate the projection
+
+## v0.92.0 on 12th of July, 2026
+
+### NOTE
+
+- WP-Praxis-0008 (Live operability & safety): the live-trading safety controls, pre-trade price/slippage gates, operator control surface, and alerting for the MVP. The operational-mode arbitration lands in Nexus (`ModeController`, halt holds, risk breakers, sole `state.mode` writer), pinned here at `0.70.0`; Praxis wires it per account and adds the pre-trade caps, price stage, slippage guard, `/ops` endpoints, and alert sink
+
+### Add
+
+- Enforce a configurable pre-trade `PRAXIS_MAX_ORDER_NOTIONAL` cap (snapshot-free) and a context-aware `PRAXIS_MAX_POSITION` cap that projects current position plus the order delta, rejecting an order that would breach either before it reaches the venue
+- Wire a per-account `ModeController` into the health loop and configure its risk breakers from the account manifest's `risk_controls` — a live daily-loss or drawdown breach HALTS the account, and `reconcile` re-derives the mode on boot before startup actions drain so a halt that outlived a restart is in force first
+- Add a loopback + bearer-token (`PRAXIS_OPS_TOKEN`, constant-time compare) `/ops` operator surface — `halt`, `resume`, `status`, `cancel-all`, `close-all` — with durable holds (persisted through the state store) and `OperatorHaltRequested` / `OperatorResumeRequested` spine audit events
+- Add an order-book cache and poller that feed the pre-trade price stage: `build_price_snapshot` derives spread and staleness, gated by `PRAXIS_MAX_SPREAD_BPS` and `PRAXIS_BOOK_STALENESS_SECONDS`
+- Reject MARKET orders whose quote-denominated estimated slippage exceeds `PRAXIS_MAX_SLIPPAGE_BPS`, reusing the shared book-walk estimator (resolves TD-078)
+- Add a minimal `AlertSink` (structured log + optional `PRAXIS_ALERT_WEBHOOK_URL` webhook) and route alerts on any HALT transition and every operator action
+- Route shutdown through the Nexus `ModeController` shutdown hold: `ShutdownSequencer` places the dedicated hold (un-liftable by a concurrent health tick) instead of writing `state.mode`, so an in-flight outcome dispatched mid-shutdown cannot resume trading
+
+### Fix
+
+- Use a non-reserved `LogRecord` key for the nexus-thread-timeout warning in `_shutdown`; `extra={'thread': ...}` raised `KeyError: Attempt to overwrite 'thread' in LogRecord` whenever a nexus thread missed its join

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -741,17 +741,7 @@ On cold start, `BinanceAdapter._filters` is empty until the first `get_exchange_
 
 **Migration**: Two options. (i) In `quantize_for_command`, treat `filters is None` as `INTAKE_FILTERS_NOT_CACHED` rejection — the launcher then drops the action and waits for the next cycle once `exchangeInfo` lands. Conservative; eats a few seconds of initial throughput on every cold start. (ii) In `Launcher.start`, gate `start_dispatch()` on a `await venue_adapter.get_exchange_info()` round-trip before opening the strategy event loop. Adds 100-200ms to cold-start; eliminates the window entirely. Option (ii) is cleaner and matches what `BinanceAdapter` already does for the WS keepalive boot sequence.
 
-## TD-078: `estimate_slippage` is observation-only — no execution guard rejects bad-fill MARKET orders
-
-**Origin**: Architectural review during v0.72.0 monkeypatch + codex round-3 design discussion (200 bps buffer hack)
-**Severity**: Low under current scope (BTCUSDT-only, $5–50 per order; BTC top-of-book on Binance routinely has $100k+ within a cent of mid so walking the book costs essentially top-of-book price). Elevated if order sizing scales by 1–2 orders of magnitude, OR during a flash-crash / liquidity-pull where top-20 depth briefly thins.
-**Module**: [`praxis/core/execution_manager.py`](../praxis/core/execution_manager.py) — `_process_command` calls [`estimate_slippage`](../praxis/core/estimate_slippage.py) at line 949 but only logs the result; no rejection path. The estimator computes `simulated_vwap` and `slippage_estimate_bps` (VWAP vs mid) and returns; the command proceeds to `venue_adapter.submit_order` regardless.
-
-The slippage estimator is wired into the pre-submit path for observability — every MARKET order log line carries `slippage_estimate_bps=...` — but there is no threshold-and-reject layer on top of it. A MARKET BUY against a pathologically thin book (flash-crash moment, exchange outage half-recovered, liquidity-provider pulled) would execute at whatever effective price the book offers, with `slippage_estimate_bps` merely logged. The capital ledger remains correct under the post-v0.73.0 `quoteOrderQty` reservation (the spend is exactly the reserved USDT, no ledger divergence is possible) but the strategy/operator receives whatever BTC qty that USDT bought; under thin-book conditions the actual BTC received could be materially below the strategy's expected sizing.
-
-**When to fix**: When either (a) an incident traces back to a thin-book bad fill where the strategy's expected BTC sizing diverged materially from the actual BTC received, OR (b) order sizing scales up significantly (e.g. ≥ $1k per order).
-
-**Migration**: Pre-submit guard in [`ExecutionManager._process_command`](../praxis/core/execution_manager.py) between the existing `estimate_slippage` call (line 949) and `submit_order`. Policy shape: `max_market_slippage_bps: int` config (default ~50, per-symbol override on [`TradingConfig`](../praxis/trading_config.py)). On violation, build a synthetic REJECTED `TradeOutcome` with `reason='EXECUTION_GUARD_SLIPPAGE_EXCEEDED'` and structured extras (`estimate.slippage_estimate_bps`, `policy.max_market_slippage_bps`, `book.top_of_book`, `cmd.symbol`) and short-circuit the venue submission. No auto-convert to LIMIT in v1 — that's a separate execution-mode feature with its own design surface. Only applies to MARKET orders; LIMIT orders self-cap via the price field.
+## TD-078: `estimate_slippage` is observation-only — no execution guard rejects bad-fill MARKET orders — RESOLVED
 
 ## TD-079: Quote-native terminal signal only on REST submit-response path — WS-driven fills do not flip to FILLED
 

--- a/praxis/core/domain/events.py
+++ b/praxis/core/domain/events.py
@@ -22,6 +22,8 @@ __all__ = [
     'FillReceived',
     'FundTransaction',
     'MarkSampled',
+    'OperatorHaltRequested',
+    'OperatorResumeRequested',
     'OrderAcked',
     'OrderCanceled',
     'OrderExpired',
@@ -536,6 +538,48 @@ class FundTransaction(_EventBase):
 
 
 @dataclass(frozen=True)
+class OperatorHaltRequested(_EventBase):
+
+    '''
+    Represent an operator's manual request to halt trading on an account.
+
+    Args:
+        account_id (str): Account that owns this event.
+        timestamp (datetime): Event time, must be timezone-aware.
+        reason (str): Operator-supplied reason for the halt.
+    '''
+
+    reason: str
+
+    def __post_init__(self) -> None:
+
+        super().__post_init__()
+
+        _require_str(type(self).__name__, 'reason', self.reason)
+
+
+@dataclass(frozen=True)
+class OperatorResumeRequested(_EventBase):
+
+    '''
+    Represent an operator's manual request to resume trading on an account.
+
+    Args:
+        account_id (str): Account that owns this event.
+        timestamp (datetime): Event time, must be timezone-aware.
+        reason (str): Operator-supplied reason for the resume.
+    '''
+
+    reason: str
+
+    def __post_init__(self) -> None:
+
+        super().__post_init__()
+
+        _require_str(type(self).__name__, 'reason', self.reason)
+
+
+@dataclass(frozen=True)
 class TradeOutcomeProduced(_EventBase):
 
     '''
@@ -766,4 +810,6 @@ type Event = (
     | MarkSampled
     | RegisterAccount
     | FundTransaction
+    | OperatorHaltRequested
+    | OperatorResumeRequested
 )

--- a/praxis/core/estimate_slippage.py
+++ b/praxis/core/estimate_slippage.py
@@ -41,14 +41,24 @@ class SlippageEstimate:
 
 
 def _mid_price(book: OrderBookSnapshot) -> Decimal | None:
-    '''Return the book mid-price, or `None` when a side is empty or it is zero.'''
+    '''Return the book mid-price, or `None` for an empty, non-positive, or crossed book.
+
+    Degrades to `None` on a bad book (a side is empty, the best bid is not
+    positive, or the best ask is below the best bid) rather than returning
+    a negative or misleading mid into the slippage estimate and guard,
+    consistent with `book_mid_price` and `build_price_snapshot`.
+    '''
 
     if not book.bids or not book.asks:
         return None
 
-    mid = (book.bids[0].price + book.asks[0].price) / _TWO
+    best_bid = book.bids[0].price
+    best_ask = book.asks[0].price
 
-    return mid if mid != _ZERO else None
+    if best_bid <= _ZERO or best_ask < best_bid:
+        return None
+
+    return (best_bid + best_ask) / _TWO
 
 
 def _slippage_from_fill(mid_price: Decimal, cost: Decimal, filled: Decimal) -> SlippageEstimate:

--- a/praxis/core/estimate_slippage.py
+++ b/praxis/core/estimate_slippage.py
@@ -131,15 +131,16 @@ def estimate_slippage_for_quote(
     symbol: str | None = None,
 ) -> SlippageEstimate | None:
     '''
-    Compute expected slippage for a quote-denominated spend by walking the book.
+    Compute expected slippage for a quote-denominated order by walking the book.
 
-    Walk ask levels for BUY orders, bid levels for SELL orders, spending
+    Walk ask levels for BUY orders, bid levels for SELL orders, consuming
     the quote amount level by level until it is exhausted or book depth
     runs out. Used for quote-native MARKET orders that have no base target.
 
     Args:
         book (OrderBookSnapshot): Current order book snapshot.
-        quote_qty (Decimal): Quote-asset amount to spend.
+        quote_qty (Decimal): Quote-asset amount — the spend for a BUY, the
+            proceeds target for a SELL.
         side (OrderSide): Order side determining which book side to walk.
         symbol (str | None): Symbol used for warning-log correlation.
 

--- a/praxis/core/estimate_slippage.py
+++ b/praxis/core/estimate_slippage.py
@@ -14,7 +14,7 @@ from decimal import Decimal
 from praxis.core.domain.enums import OrderSide
 from praxis.infrastructure.venue_adapter import OrderBookSnapshot
 
-__all__ = ['SlippageEstimate', 'estimate_slippage']
+__all__ = ['SlippageEstimate', 'estimate_slippage', 'estimate_slippage_for_quote']
 
 _log = logging.getLogger(__name__)
 
@@ -38,6 +38,30 @@ class SlippageEstimate:
     mid_price: Decimal
     simulated_vwap: Decimal
     slippage_estimate_bps: Decimal
+
+
+def _mid_price(book: OrderBookSnapshot) -> Decimal | None:
+    '''Return the book mid-price, or `None` when a side is empty or it is zero.'''
+
+    if not book.bids or not book.asks:
+        return None
+
+    mid = (book.bids[0].price + book.asks[0].price) / _TWO
+
+    return mid if mid != _ZERO else None
+
+
+def _slippage_from_fill(mid_price: Decimal, cost: Decimal, filled: Decimal) -> SlippageEstimate:
+    '''Build a `SlippageEstimate` from the walked cost and filled base quantity.'''
+
+    simulated_vwap = cost / filled
+    slippage_bps = (simulated_vwap - mid_price) / mid_price * _BPS_MULTIPLIER
+
+    return SlippageEstimate(
+        mid_price=mid_price,
+        simulated_vwap=simulated_vwap,
+        slippage_estimate_bps=slippage_bps,
+    )
 
 
 def estimate_slippage(
@@ -67,12 +91,9 @@ def estimate_slippage(
             a bid or an ask (mid-price cannot be computed).
     '''
 
-    if not book.bids or not book.asks:
-        return None
+    mid_price = _mid_price(book)
 
-    mid_price = (book.bids[0].price + book.asks[0].price) / _TWO
-
-    if mid_price == _ZERO:
+    if mid_price is None:
         return None
 
     levels = book.asks if side == OrderSide.BUY else book.bids
@@ -100,11 +121,59 @@ def estimate_slippage(
             side.value,
         )
 
-    simulated_vwap = cost / filled
-    slippage_bps = (simulated_vwap - mid_price) / mid_price * _BPS_MULTIPLIER
+    return _slippage_from_fill(mid_price, cost, filled)
 
-    return SlippageEstimate(
-        mid_price=mid_price,
-        simulated_vwap=simulated_vwap,
-        slippage_estimate_bps=slippage_bps,
-    )
+
+def estimate_slippage_for_quote(
+    book: OrderBookSnapshot,
+    quote_qty: Decimal,
+    side: OrderSide,
+    symbol: str | None = None,
+) -> SlippageEstimate | None:
+    '''
+    Compute expected slippage for a quote-denominated spend by walking the book.
+
+    Walk ask levels for BUY orders, bid levels for SELL orders, spending
+    the quote amount level by level until it is exhausted or book depth
+    runs out. Used for quote-native MARKET orders that have no base target.
+
+    Args:
+        book (OrderBookSnapshot): Current order book snapshot.
+        quote_qty (Decimal): Quote-asset amount to spend.
+        side (OrderSide): Order side determining which book side to walk.
+        symbol (str | None): Symbol used for warning-log correlation.
+
+    Returns:
+        SlippageEstimate | None: Estimate with mid-price, simulated VWAP,
+            and slippage in bps. None when the book lacks a bid or an ask,
+            or when no base could be filled.
+    '''
+
+    mid_price = _mid_price(book)
+
+    if mid_price is None:
+        return None
+
+    levels = book.asks if side == OrderSide.BUY else book.bids
+    remaining_quote = quote_qty
+    filled_base = _ZERO
+
+    for level in levels:
+        if remaining_quote <= _ZERO:
+            break
+        spend = min(remaining_quote, level.qty * level.price)
+        filled_base += spend / level.price
+        remaining_quote -= spend
+
+    if filled_base == _ZERO:
+        return None
+
+    if remaining_quote > _ZERO:
+        _log.warning(
+            'book depth insufficient for quote spend: symbol=%s needed_quote=%s side=%s',
+            symbol,
+            quote_qty,
+            side.value,
+        )
+
+    return _slippage_from_fill(mid_price, quote_qty - remaining_quote, filled_base)

--- a/praxis/core/estimate_slippage.py
+++ b/praxis/core/estimate_slippage.py
@@ -171,7 +171,7 @@ def estimate_slippage_for_quote(
 
     if remaining_quote > _ZERO:
         _log.warning(
-            'book depth insufficient for quote spend: symbol=%s needed_quote=%s side=%s',
+            'book depth insufficient for quote amount: symbol=%s needed_quote=%s side=%s',
             symbol,
             quote_qty,
             side.value,

--- a/praxis/core/execution_manager.py
+++ b/praxis/core/execution_manager.py
@@ -53,7 +53,11 @@ from praxis.core.domain.trade_pnl import TradePnL
 from praxis.core.domain.single_shot_params import SingleShotParams
 from praxis.core.domain.trade_abort import TradeAbort
 from praxis.core.domain.trade_command import TradeCommand
-from praxis.core.estimate_slippage import estimate_slippage
+from praxis.core.estimate_slippage import (
+    SlippageEstimate,
+    estimate_slippage,
+    estimate_slippage_for_quote,
+)
 from praxis.core.generate_client_order_id import (
     generate_client_order_id,
     validate_command_id_for_client_order_id,
@@ -160,12 +164,14 @@ class ExecutionManager:
         venue_adapter: VenueAdapter,
         on_trade_outcome: Callable[[TradeOutcome], Awaitable[None]] | None = None,
         clock: Callable[[], datetime] = _utc_now,
+        max_slippage_bps: Decimal | None = None,
     ) -> None:
         '''Store dependencies and initialize empty account registry.'''
 
         self._event_spine = event_spine
         self._epoch_id = epoch_id
         self._venue_adapter = venue_adapter
+        self._max_slippage_bps = max_slippage_bps
         self._on_trade_outcome = on_trade_outcome
         self._clock = clock
         self._accounts: dict[str, _AccountRuntime] = {}
@@ -1120,7 +1126,43 @@ class ExecutionManager:
         finally:
             _log.info('account loop exited: %s', runtime.account_id)
 
-    async def _process_command(
+    def _slippage_guard_reason(
+        self, cmd: TradeCommand, estimate: SlippageEstimate | None,
+    ) -> str | None:
+        '''Return a rejection reason when a MARKET order's estimated slippage is too wide.
+
+        Guards MARKET orders only; a LIMIT order self-caps at its price. The
+        adverse direction is positive slippage for a BUY and negative for a
+        SELL, so both are compared as a positive breach against the limit.
+        '''
+
+        if (
+            self._max_slippage_bps is None
+            or estimate is None
+            or cmd.order_type is not OrderType.MARKET
+        ):
+            return None
+
+        adverse_bps = (
+            estimate.slippage_estimate_bps
+            if cmd.side is OrderSide.BUY
+            else -estimate.slippage_estimate_bps
+        )
+
+        if adverse_bps <= self._max_slippage_bps:
+            return None
+
+        _log.warning(
+            'slippage guard rejected: command_id=%s trade_id=%s adverse_bps=%s max_bps=%s',
+            cmd.command_id,
+            cmd.trade_id,
+            adverse_bps,
+            self._max_slippage_bps,
+        )
+
+        return f'estimated slippage {adverse_bps} bps exceeds max {self._max_slippage_bps} bps'
+
+    async def _process_command(  # noqa: PLR0911 - one return per pre-submit rejection reason
         self,
         runtime: _AccountRuntime,
         cmd: TradeCommand,
@@ -1177,36 +1219,54 @@ class ExecutionManager:
             )
 
         estimate = None
-        if not cmd.is_quote_native:
-            assert cmd.qty is not None
-            try:
-                book = await self._venue_adapter.query_order_book(
-                    cmd.symbol,
-                    limit=_SLIPPAGE_BOOK_LIMIT,
+        try:
+            book = await self._venue_adapter.query_order_book(
+                cmd.symbol,
+                limit=_SLIPPAGE_BOOK_LIMIT,
+            )
+            if cmd.is_quote_native:
+                assert cmd.quote_qty is not None
+                estimate = estimate_slippage_for_quote(
+                    book, cmd.quote_qty, cmd.side, symbol=cmd.symbol,
                 )
+            else:
+                assert cmd.qty is not None
                 estimate = estimate_slippage(book, cmd.qty, cmd.side, symbol=cmd.symbol)
-                if estimate is None:
-                    _log.warning(
-                        'slippage estimate unavailable: command_id=%s trade_id=%s',
-                        cmd.command_id,
-                        cmd.trade_id,
-                    )
-                else:
-                    _log.info(
-                        'slippage estimate computed: command_id=%s trade_id=%s slippage_estimate_bps=%s mid_price=%s simulated_vwap=%s',
-                        cmd.command_id,
-                        cmd.trade_id,
-                        estimate.slippage_estimate_bps,
-                        estimate.mid_price,
-                        estimate.simulated_vwap,
-                    )
-            except VenueError as exc:
+
+            if estimate is None:
                 _log.warning(
-                    'slippage estimate skipped: command_id=%s trade_id=%s reason=%s',
+                    'slippage estimate unavailable: command_id=%s trade_id=%s',
                     cmd.command_id,
                     cmd.trade_id,
-                    exc.args[0] if exc.args else str(exc),
                 )
+            else:
+                _log.info(
+                    'slippage estimate computed: command_id=%s trade_id=%s slippage_estimate_bps=%s mid_price=%s simulated_vwap=%s',
+                    cmd.command_id,
+                    cmd.trade_id,
+                    estimate.slippage_estimate_bps,
+                    estimate.mid_price,
+                    estimate.simulated_vwap,
+                )
+        except VenueError as exc:
+            _log.warning(
+                'slippage estimate skipped: command_id=%s trade_id=%s reason=%s',
+                cmd.command_id,
+                cmd.trade_id,
+                exc.args[0] if exc.args else str(exc),
+            )
+
+        slippage_reject = self._slippage_guard_reason(cmd, estimate)
+
+        if slippage_reject is not None:
+            return await self._build_outcome(
+                runtime,
+                cmd,
+                TradeStatus.REJECTED,
+                filled_qty=_ZERO,
+                avg_fill_price=None,
+                reason=slippage_reject,
+            )
 
         client_order_id = generate_client_order_id(
             cmd.execution_mode,

--- a/praxis/infrastructure/alert_sink.py
+++ b/praxis/infrastructure/alert_sink.py
@@ -60,7 +60,9 @@ class AlertSink:
         if self._webhook_url is None or self._post is None:
             return
 
-        payload = {'event': event, 'severity': severity, **detail}
+        payload = json.loads(
+            json.dumps({'event': event, 'severity': severity, **detail}, default=str),
+        )
 
         try:
             await self._post(self._webhook_url, payload)

--- a/praxis/infrastructure/alert_sink.py
+++ b/praxis/infrastructure/alert_sink.py
@@ -37,18 +37,25 @@ class AlertSink:
         self._webhook_url = webhook_url
         self._post = post
 
-    def alert(self, event: str, severity: str = 'warning', **detail: Any) -> None:
-        '''Emit a structured alert log line. Safe from any thread.'''
+    def alert(self, event: str, severity: str = 'warning', **detail: Any) -> str:
+        '''Emit a structured alert log line. Safe from any thread.
+
+        Returns:
+            The severity actually used, normalised to `warning` when the
+            argument is not a known severity.
+        '''
 
         if severity not in _SEVERITIES:
             severity = 'warning'
 
         _log.warning('ALERT event=%s severity=%s detail=%s', event, severity, json.dumps(detail, default=str))
 
+        return severity
+
     async def notify(self, event: str, severity: str = 'warning', **detail: Any) -> None:
         '''Log the alert and best-effort POST it to the webhook when configured.'''
 
-        self.alert(event, severity, **detail)
+        severity = self.alert(event, severity, **detail)
 
         if self._webhook_url is None or self._post is None:
             return

--- a/praxis/infrastructure/alert_sink.py
+++ b/praxis/infrastructure/alert_sink.py
@@ -1,0 +1,61 @@
+'''Minimal alert routing: a structured log line plus an optional webhook.
+
+Emits one greppable `ALERT` log line per event (the reliable routing
+primitive an external log pipeline pages on) and, when a webhook is
+configured, best-effort POSTs the same payload. A webhook failure is
+logged and never propagates, so alerting can never break trading.
+'''
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+__all__ = ['AlertSink']
+
+_log = logging.getLogger(__name__)
+
+_SEVERITIES = frozenset({'info', 'warning', 'critical'})
+
+
+class AlertSink:
+    '''Route operational alerts to a structured log line and an optional webhook.
+
+    Args:
+        webhook_url: Destination for the optional POST, or `None` to log only.
+        post: Async `(url, payload) -> None` used to deliver the webhook;
+            injected so callers own the HTTP client and tests can stub it.
+    '''
+
+    def __init__(
+        self,
+        webhook_url: str | None = None,
+        post: Callable[[str, dict[str, Any]], Awaitable[None]] | None = None,
+    ) -> None:
+        self._webhook_url = webhook_url
+        self._post = post
+
+    def alert(self, event: str, severity: str = 'warning', **detail: Any) -> None:
+        '''Emit a structured alert log line. Safe from any thread.'''
+
+        if severity not in _SEVERITIES:
+            severity = 'warning'
+
+        _log.warning('ALERT event=%s severity=%s detail=%s', event, severity, json.dumps(detail, default=str))
+
+    async def notify(self, event: str, severity: str = 'warning', **detail: Any) -> None:
+        '''Log the alert and best-effort POST it to the webhook when configured.'''
+
+        self.alert(event, severity, **detail)
+
+        if self._webhook_url is None or self._post is None:
+            return
+
+        payload = {'event': event, 'severity': severity, **detail}
+
+        try:
+            await self._post(self._webhook_url, payload)
+        except Exception:  # noqa: BLE001 - alerting must never break the caller
+            _log.exception('alert webhook failed: event=%s', event)

--- a/praxis/infrastructure/book_cache.py
+++ b/praxis/infrastructure/book_cache.py
@@ -1,0 +1,90 @@
+'''Cache of the latest order book per symbol for pre-trade price checks.
+
+A poller writes the most recent `OrderBookSnapshot` per symbol; the
+validation pipeline's price-snapshot provider reads it to derive spread
+and staleness without a blocking venue call on the hot path.
+'''
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+
+from nexus.core.validator import PriceCheckSnapshot
+
+from praxis.infrastructure.venue_adapter import OrderBookSnapshot
+
+__all__ = ['BookCache', 'build_price_snapshot']
+
+_ZERO = Decimal('0')
+_TWO = Decimal('2')
+_BPS = Decimal('10000')
+_MS_PER_SECOND = 1000
+
+
+@dataclass
+class _CachedBook:
+    snapshot: OrderBookSnapshot
+    fetched_at: datetime
+
+
+class BookCache:
+    '''The most recent order book per symbol, written by the poller and read during validation.'''
+
+    def __init__(self) -> None:
+        self._books: dict[str, _CachedBook] = {}
+        self._lock = threading.Lock()
+
+    def update(self, symbol: str, snapshot: OrderBookSnapshot, fetched_at: datetime) -> None:
+        '''Store the latest snapshot for `symbol` with its fetch time.'''
+
+        with self._lock:
+            self._books[symbol] = _CachedBook(snapshot=snapshot, fetched_at=fetched_at)
+
+    def get(self, symbol: str) -> _CachedBook | None:
+        '''Return the cached book for `symbol`, or `None` when absent.'''
+
+        with self._lock:
+            return self._books.get(symbol)
+
+
+def build_price_snapshot(
+    cache: BookCache, symbol: str, now: datetime,
+) -> PriceCheckSnapshot | None:
+    '''Build a `PriceCheckSnapshot` from the cached book, or `None`.
+
+    Returns `None` when no book is cached or the book is empty or crossed,
+    so a configured price limit rejects rather than trades on a bad book.
+
+    Args:
+        cache: Book cache the poller keeps current.
+        symbol: Symbol to read.
+        now: Current time, for the staleness reference.
+    '''
+
+    cached = cache.get(symbol)
+
+    if cached is None:
+        return None
+
+    snapshot = cached.snapshot
+
+    if not snapshot.bids or not snapshot.asks:
+        return None
+
+    best_bid = snapshot.bids[0].price
+    best_ask = snapshot.asks[0].price
+
+    if best_bid <= _ZERO or best_ask < best_bid:
+        return None
+
+    mid = (best_bid + best_ask) / _TWO
+    spread_bps = (best_ask - best_bid) / mid * _BPS
+
+    return PriceCheckSnapshot(
+        now_ms=int(now.timestamp() * _MS_PER_SECOND),
+        book_timestamp_ms=int(cached.fetched_at.timestamp() * _MS_PER_SECOND),
+        spread_bps=spread_bps,
+    )

--- a/praxis/infrastructure/book_cache.py
+++ b/praxis/infrastructure/book_cache.py
@@ -24,7 +24,7 @@ _BPS = Decimal('10000')
 _MS_PER_SECOND = 1000
 
 
-@dataclass
+@dataclass(frozen=True)
 class CachedBook:
     snapshot: OrderBookSnapshot
     fetched_at: datetime

--- a/praxis/infrastructure/book_cache.py
+++ b/praxis/infrastructure/book_cache.py
@@ -16,7 +16,7 @@ from nexus.core.validator import PriceCheckSnapshot
 
 from praxis.infrastructure.venue_adapter import OrderBookSnapshot
 
-__all__ = ['BookCache', 'build_price_snapshot']
+__all__ = ['BookCache', 'CachedBook', 'build_price_snapshot']
 
 _ZERO = Decimal('0')
 _TWO = Decimal('2')
@@ -25,7 +25,7 @@ _MS_PER_SECOND = 1000
 
 
 @dataclass
-class _CachedBook:
+class CachedBook:
     snapshot: OrderBookSnapshot
     fetched_at: datetime
 
@@ -34,16 +34,16 @@ class BookCache:
     '''The most recent order book per symbol, written by the poller and read during validation.'''
 
     def __init__(self) -> None:
-        self._books: dict[str, _CachedBook] = {}
+        self._books: dict[str, CachedBook] = {}
         self._lock = threading.Lock()
 
     def update(self, symbol: str, snapshot: OrderBookSnapshot, fetched_at: datetime) -> None:
         '''Store the latest snapshot for `symbol` with its fetch time.'''
 
         with self._lock:
-            self._books[symbol] = _CachedBook(snapshot=snapshot, fetched_at=fetched_at)
+            self._books[symbol] = CachedBook(snapshot=snapshot, fetched_at=fetched_at)
 
-    def get(self, symbol: str) -> _CachedBook | None:
+    def get(self, symbol: str) -> CachedBook | None:
         '''Return the cached book for `symbol`, or `None` when absent.'''
 
         with self._lock:

--- a/praxis/infrastructure/book_cache.py
+++ b/praxis/infrastructure/book_cache.py
@@ -16,7 +16,7 @@ from nexus.core.validator import PriceCheckSnapshot
 
 from praxis.infrastructure.venue_adapter import OrderBookSnapshot
 
-__all__ = ['BookCache', 'CachedBook', 'build_price_snapshot']
+__all__ = ['BookCache', 'CachedBook', 'book_mid_price', 'build_price_snapshot']
 
 _ZERO = Decimal('0')
 _TWO = Decimal('2')
@@ -48,6 +48,37 @@ class BookCache:
 
         with self._lock:
             return self._books.get(symbol)
+
+
+def book_mid_price(cache: BookCache, symbol: str) -> Decimal | None:
+    '''Return the cached top-of-book mid for `symbol`, or `None`.
+
+    `None` when no book is cached, the book is empty, or it is crossed, so
+    a caller converting a quote notional to a base size degrades safely
+    rather than dividing by a bad price.
+
+    Args:
+        cache: Book cache the poller keeps current.
+        symbol: Symbol to read.
+    '''
+
+    cached = cache.get(symbol)
+
+    if cached is None:
+        return None
+
+    snapshot = cached.snapshot
+
+    if not snapshot.bids or not snapshot.asks:
+        return None
+
+    best_bid = snapshot.bids[0].price
+    best_ask = snapshot.asks[0].price
+
+    if best_bid <= _ZERO or best_ask < best_bid:
+        return None
+
+    return (best_bid + best_ask) / _TWO
 
 
 def build_price_snapshot(

--- a/praxis/infrastructure/book_poller.py
+++ b/praxis/infrastructure/book_poller.py
@@ -1,0 +1,91 @@
+'''Background poller that keeps the `BookCache` current from the venue.'''
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from collections.abc import Awaitable, Callable
+from datetime import datetime
+
+from praxis.infrastructure.book_cache import BookCache
+from praxis.infrastructure.venue_adapter import OrderBookSnapshot
+
+__all__ = ['BookPoller']
+
+_log = logging.getLogger(__name__)
+
+
+class BookPoller:
+    '''Polls the venue order book for one symbol and updates the cache.'''
+
+    def __init__(
+        self,
+        symbol: str,
+        fetch: Callable[[], Awaitable[OrderBookSnapshot]],
+        cache: BookCache,
+        clock: Callable[[], datetime],
+        interval_seconds: float,
+    ) -> None:
+
+        if not symbol:
+            raise ValueError('symbol must be a non-empty string')
+
+        if interval_seconds <= 0:
+            raise ValueError(f'interval_seconds must be positive, got {interval_seconds}')
+
+        self._symbol = symbol
+        self._fetch = fetch
+        self._cache = cache
+        self._clock = clock
+        self._interval_seconds = interval_seconds
+        self._task: asyncio.Task[None] | None = None
+        self._stop_event = asyncio.Event()
+
+    @property
+    def running(self) -> bool:
+        return self._task is not None and not self._task.done()
+
+    def start(self) -> None:
+        '''Start the background polling loop.'''
+
+        if self.running:
+            raise RuntimeError('BookPoller already running')
+
+        self._stop_event.clear()
+        self._task = asyncio.create_task(
+            self._loop(), name=f'book-poller-{self._symbol}',
+        )
+
+    async def stop(self) -> None:
+        '''Signal the loop to exit, then cancel and await it.'''
+
+        self._stop_event.set()
+
+        if self._task is not None:
+            self._task.cancel()
+
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._task
+
+            self._task = None
+
+    async def tick_once(self) -> None:
+        '''Fetch the order book once and update the cache.'''
+
+        snapshot = await self._fetch()
+        self._cache.update(self._symbol, snapshot, self._clock())
+
+    async def _loop(self) -> None:
+
+        while not self._stop_event.is_set():
+
+            try:
+                await self.tick_once()
+            except Exception:  # noqa: BLE001 - a poll failure must not stop the loop
+                _log.exception('book poll tick failed; continuing')
+
+            try:
+                await asyncio.wait_for(self._stop_event.wait(), self._interval_seconds)
+            except TimeoutError:
+                continue

--- a/praxis/infrastructure/event_spine.py
+++ b/praxis/infrastructure/event_spine.py
@@ -44,6 +44,8 @@ from praxis.core.domain.events import (
     OutcomeAcked,
     OutcomeDeliveryContextRecorded,
     OutcomeReplayAbandoned,
+    OperatorHaltRequested,
+    OperatorResumeRequested,
     RegisterAccount,
     TradeClosed,
     TradeOutcomeProduced,
@@ -114,6 +116,8 @@ _EVENT_REGISTRY: dict[str, type] = {
         MarkSampled,
         RegisterAccount,
         FundTransaction,
+        OperatorHaltRequested,
+        OperatorResumeRequested,
     )
 }
 

--- a/praxis/launcher.py
+++ b/praxis/launcher.py
@@ -3121,6 +3121,7 @@ class Launcher:
             state, positions_lock, clock=self._clock,
             risk_thresholds=manifest.risk_controls,
         )
+        mode_controller.reconcile()
         state_store.attach_snapshot_locks(
             _build_state_snapshot_locks(state, positions_lock, capital_controller),
         )

--- a/praxis/launcher.py
+++ b/praxis/launcher.py
@@ -129,7 +129,7 @@ from praxis.infrastructure.event_spine import EventSpine
 from praxis.infrastructure.observability import bind_context, configure_logging
 from praxis.outcome_translator import OutcomeTranslator
 from praxis.infrastructure.alert_sink import AlertSink
-from praxis.infrastructure.book_cache import BookCache, build_price_snapshot
+from praxis.infrastructure.book_cache import BookCache, book_mid_price, build_price_snapshot
 from praxis.infrastructure.book_poller import BookPoller
 from praxis.infrastructure.venue_adapter import OrderBookSnapshot, VenueAdapter
 from praxis.trading import Trading
@@ -466,13 +466,20 @@ def _default_platform_snapshot(
 def _projected_position(
     positions: dict[str, Position],
     context: ValidationRequestContext,
+    mid_price_provider: Callable[[str], Decimal | None],
 ) -> Decimal:
     '''Return the account's projected base position for the context's order.
 
     Sums current open positions in the order's symbol (long positive, short
-    negative) and applies the pending order's signed size, so the
+    negative) and applies the pending order's signed base size, so the
     platform-limits stage gates the position the order would leave, not the
     position before it. Floored at zero.
+
+    A quote-native order carries `order_notional` but no `order_size`, so
+    its base delta is estimated as `order_notional / mid`, where `mid` is
+    the cached top-of-book mid. When no mid is available the delta is zero
+    (the cap degrades to gating the current position), and `order_size`
+    stays `None` so the estimate never leaks onto the delivered order.
     '''
 
     current = sum(
@@ -480,7 +487,16 @@ def _projected_position(
          for position in positions.values() if position.symbol == context.symbol),
         _ZERO,
     )
-    delta = context.order_size or _ZERO
+
+    if context.order_size is not None:
+        delta = context.order_size
+
+    elif context.order_notional is not None:
+        mid = mid_price_provider(context.symbol)
+        delta = context.order_notional / mid if mid is not None and mid > _ZERO else _ZERO
+
+    else:
+        delta = _ZERO
 
     if context.order_side is OrderSide.SELL:
         delta = -delta
@@ -493,6 +509,7 @@ def _projected_position(
 def _build_platform_snapshot_provider(
     positions: dict[str, Position],
     positions_lock: threading.Lock,
+    mid_price_provider: Callable[[str], Decimal | None],
 ) -> Callable[[ValidationRequestContext], PlatformLimitsStageSnapshot]:
     '''Return a provider that projects the account position for each order.
 
@@ -502,6 +519,8 @@ def _build_platform_snapshot_provider(
             deletes; the provider runs at validation time on the strategy
             thread, outside the validator's lock, so it snapshots under this
             lock to avoid a `dictionary changed size during iteration` race.
+        mid_price_provider: Maps a symbol to its cached top-of-book mid,
+            used to project a quote-native order's base delta.
     '''
 
     def provider(context: ValidationRequestContext) -> PlatformLimitsStageSnapshot:
@@ -509,7 +528,7 @@ def _build_platform_snapshot_provider(
             snapshot = dict(positions)
 
         return PlatformLimitsStageSnapshot(
-            projected_position=_projected_position(snapshot, context),
+            projected_position=_projected_position(snapshot, context, mid_price_provider),
         )
 
     return provider
@@ -3152,7 +3171,7 @@ class Launcher:
         return provider
 
     def _start_book_pollers(self) -> None:
-        '''Start one order-book poller per account on the launcher loop.
+        '''Start one order-book poller per unique symbol on the launcher loop.
 
         Best-effort: a start failure is logged and leaves trading unaffected,
         since an absent book only makes a configured price limit reject.
@@ -3424,6 +3443,7 @@ class Launcher:
             nexus_instance_config, capital_controller,
             platform_snapshot_provider=_build_platform_snapshot_provider(
                 state.positions, positions_lock,
+                lambda symbol: book_mid_price(self._book_cache, symbol),
             ),
             platform_limits=PlatformLimitsStageLimits(
                 max_order_notional=_env_positive_decimal('PRAXIS_MAX_ORDER_NOTIONAL'),

--- a/praxis/launcher.py
+++ b/praxis/launcher.py
@@ -19,7 +19,7 @@ import signal
 import sys
 import threading
 import uuid
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from decimal import Decimal, InvalidOperation
@@ -128,7 +128,9 @@ from praxis.paper.paper_report import build_paper_report
 from praxis.infrastructure.event_spine import EventSpine
 from praxis.infrastructure.observability import bind_context, configure_logging
 from praxis.outcome_translator import OutcomeTranslator
-from praxis.infrastructure.venue_adapter import VenueAdapter
+from praxis.infrastructure.book_cache import BookCache, build_price_snapshot
+from praxis.infrastructure.book_poller import BookPoller
+from praxis.infrastructure.venue_adapter import OrderBookSnapshot, VenueAdapter
 from praxis.trading import Trading
 from praxis.trading_config import TradingConfig
 
@@ -154,6 +156,7 @@ _DEFAULT_FEE_RATE = Decimal('0.001')
 _DEFAULT_SYMBOL = 'BTCUSDT'
 _LOOPBACK_HOSTS = frozenset({'127.0.0.1', '::1'})
 _OPS_CLOSE_TIMEOUT_SECONDS = 60
+_DEFAULT_BOOK_POLL_INTERVAL_SECONDS = 2.0
 
 
 def _utc_now() -> datetime:
@@ -484,7 +487,7 @@ def _build_platform_snapshot_provider(
     return provider
 
 
-def _default_price_snapshot() -> PriceCheckSnapshot | None:
+def _default_price_snapshot(_context: ValidationRequestContext) -> PriceCheckSnapshot | None:
     '''Return `None`; MMVP `PriceStageLimits` are all unset.'''
 
     return None
@@ -531,7 +534,7 @@ def _build_validation_pipeline(
     platform_snapshot_provider: Callable[[ValidationRequestContext], PlatformLimitsStageSnapshot] = (
         _default_platform_snapshot
     ),
-    price_snapshot_provider: Callable[[], PriceCheckSnapshot | None] = (
+    price_snapshot_provider: Callable[[ValidationRequestContext], PriceCheckSnapshot | None] = (
         _default_price_snapshot
     ),
     platform_limits: PlatformLimitsStageLimits | None = None,
@@ -599,7 +602,7 @@ def _build_validation_pipeline(
         return validate_price_stage(
             context,
             price_limits,
-            price_snapshot_provider(),
+            price_snapshot_provider(context),
         )
 
     def capital(context: ValidationRequestContext) -> ValidationDecision:
@@ -2244,6 +2247,8 @@ class Launcher:
         self._healthz_runner: web.AppRunner | None = None
         self._paper_accounts: dict[str, _PaperAccount] | None = None
         self._mark_samplers: list[MarkSampler] = []
+        self._book_cache = BookCache()
+        self._book_pollers: list[BookPoller] = []
         self._outcome_queues: dict[str, queue.Queue[NexusTradeOutcome]] = {}
         self._outcome_translator = OutcomeTranslator(fee_rate=_DEFAULT_FEE_RATE)
         self._account_outcome_wiring: dict[str, _AccountOutcomeWiring] = {}
@@ -2266,6 +2271,7 @@ class Launcher:
         self._start_nexus_instances()
         self._start_healthz()
         self._start_mark_samplers()
+        self._start_book_pollers()
 
         _log.info('all nexus instances started', extra={'count': len(self._nexus_threads)})
 
@@ -3011,6 +3017,87 @@ class Launcher:
         else:
             self._mark_samplers = []
 
+    def _build_price_snapshot_provider(
+        self,
+    ) -> Callable[[ValidationRequestContext], PriceCheckSnapshot | None]:
+        '''Return a provider reading the cached book for the order's symbol.'''
+
+        def provider(context: ValidationRequestContext) -> PriceCheckSnapshot | None:
+            return build_price_snapshot(self._book_cache, context.symbol, self._clock())
+
+        return provider
+
+    def _start_book_pollers(self) -> None:
+        '''Start one order-book poller per account on the launcher loop.
+
+        Best-effort: a start failure is logged and leaves trading unaffected,
+        since an absent book only makes a configured price limit reject.
+        '''
+
+        if self._loop is None or self._venue_adapter is None:
+            return
+
+        future = asyncio.run_coroutine_threadsafe(self._build_book_pollers(), self._loop)
+
+        try:
+            future.result(timeout=10)
+        except Exception:  # noqa: BLE001 - book polling must never abort trading
+            future.cancel()
+            _log.exception('book poller startup failed; the build can retry')
+        else:
+            _log.info('book pollers started', extra={'count': len(self._book_pollers)})
+
+    async def _build_book_pollers(self) -> None:
+        venue_adapter = self._venue_adapter
+
+        if venue_adapter is None or self._book_pollers:
+            return
+
+        pollers: list[BookPoller] = []
+
+        try:
+            for account in self._paper_account_map().values():
+
+                def fetch(symbol: str = account.symbol) -> Awaitable[OrderBookSnapshot]:
+                    return venue_adapter.query_order_book(symbol)
+
+                poller = BookPoller(
+                    symbol=account.symbol, fetch=fetch, cache=self._book_cache,
+                    clock=self._clock, interval_seconds=_DEFAULT_BOOK_POLL_INTERVAL_SECONDS,
+                )
+                pollers.append(poller)
+                poller.start()
+
+        except Exception:
+            for poller in pollers:
+                await poller.stop()
+
+            raise
+
+        self._book_pollers = pollers
+
+    def _stop_book_pollers(self) -> None:
+        '''Stop every book poller; best-effort during shutdown.'''
+
+        if self._loop is None or not self._book_pollers:
+            return
+
+        pollers = self._book_pollers
+
+        async def _stop_all() -> None:
+            for poller in pollers:
+                await poller.stop()
+
+        future = asyncio.run_coroutine_threadsafe(_stop_all(), self._loop)
+
+        try:
+            future.result(timeout=10)
+        except Exception:  # noqa: BLE001 - best effort during shutdown
+            future.cancel()
+            _log.exception('book poller shutdown failed; keeping references for retry')
+        else:
+            self._book_pollers = []
+
     async def _healthz_handler(self, _request: web.Request) -> web.Response:
         failures: list[str] = []
 
@@ -3055,6 +3142,7 @@ class Launcher:
 
     def _shutdown(self) -> None:
         self._stop_mark_samplers()
+        self._stop_book_pollers()
 
         for thread in self._nexus_threads:
             thread.join(timeout=30)
@@ -3214,6 +3302,7 @@ class Launcher:
                 max_order_notional=_env_positive_decimal('PRAXIS_MAX_ORDER_NOTIONAL'),
                 max_position=_env_positive_decimal('PRAXIS_MAX_POSITION'),
             ),
+            price_snapshot_provider=self._build_price_snapshot_provider(),
             clock=self._clock,
         )
         positions_lock = threading.Lock()

--- a/praxis/launcher.py
+++ b/praxis/launcher.py
@@ -2949,7 +2949,12 @@ class Launcher:
             return web.json_response({'error': 'unknown_account'}, status=404)
 
         account_id = runtime.nexus_config.account_id
-        canceled = self._cancel_all_orders(account_id)
+
+        try:
+            canceled = self._cancel_all_orders(account_id)
+        except Exception:  # noqa: BLE001 - operator endpoint returns a structured error
+            _log.exception('ops cancel-all failed', extra={'account_id': account_id})
+            return web.json_response({'error': 'cancel_all_failed'}, status=500)
 
         await self._alert_sink.notify(
             'operator_cancel_all', severity='warning',
@@ -2970,8 +2975,13 @@ class Launcher:
             return web.json_response({'error': 'unknown_account'}, status=404)
 
         account_id = runtime.nexus_config.account_id
-        canceled = self._cancel_all_orders(account_id)
-        closed = await self._close_all_positions(account_id)
+
+        try:
+            canceled = self._cancel_all_orders(account_id)
+            closed = await self._close_all_positions(account_id)
+        except Exception:  # noqa: BLE001 - operator endpoint returns a structured error
+            _log.exception('ops close-all failed', extra={'account_id': account_id})
+            return web.json_response({'error': 'close_all_failed'}, status=500)
 
         await self._alert_sink.notify(
             'operator_close_all', severity='warning',

--- a/praxis/launcher.py
+++ b/praxis/launcher.py
@@ -2970,7 +2970,10 @@ class Launcher:
             )
             raise RuntimeError(msg)
         state.risk.lock = positions_lock
-        mode_controller = ModeController(state, positions_lock, clock=self._clock)
+        mode_controller = ModeController(
+            state, positions_lock, clock=self._clock,
+            risk_thresholds=manifest.risk_controls,
+        )
         state_store.attach_snapshot_locks(
             _build_state_snapshot_locks(state, positions_lock, capital_controller),
         )

--- a/praxis/launcher.py
+++ b/praxis/launcher.py
@@ -3302,6 +3302,7 @@ class Launcher:
                 outcome_processor=runtime.outcome_processor,
                 non_pending_outcome_handler=runtime.process_outcome,
                 positions_lock=runtime.positions_lock,
+                mode_controller=runtime.mode_controller,
             )
             shutdown.shutdown()
 

--- a/praxis/launcher.py
+++ b/praxis/launcher.py
@@ -28,7 +28,7 @@ from typing import Any
 from urllib.parse import urlparse
 
 import aiosqlite
-from aiohttp import web
+from aiohttp import ClientSession, ClientTimeout, web
 
 from nexus.core.capital_controller.capital_controller import CapitalController
 from nexus.core.domain.enums import OperationalMode, OrderSide
@@ -128,6 +128,7 @@ from praxis.paper.paper_report import build_paper_report
 from praxis.infrastructure.event_spine import EventSpine
 from praxis.infrastructure.observability import bind_context, configure_logging
 from praxis.outcome_translator import OutcomeTranslator
+from praxis.infrastructure.alert_sink import AlertSink
 from praxis.infrastructure.book_cache import BookCache, build_price_snapshot
 from praxis.infrastructure.book_poller import BookPoller
 from praxis.infrastructure.venue_adapter import OrderBookSnapshot, VenueAdapter
@@ -157,6 +158,7 @@ _DEFAULT_SYMBOL = 'BTCUSDT'
 _LOOPBACK_HOSTS = frozenset({'127.0.0.1', '::1'})
 _OPS_CLOSE_TIMEOUT_SECONDS = 60
 _DEFAULT_BOOK_POLL_INTERVAL_SECONDS = 2.0
+_ALERT_WEBHOOK_TIMEOUT_SECONDS = 5
 
 
 def _utc_now() -> datetime:
@@ -555,6 +557,15 @@ def _env_positive_int(name: str) -> int | None:
         raise ValueError(msg)
 
     return value
+
+
+async def _post_alert_webhook(url: str, payload: dict[str, Any]) -> None:
+    '''POST an alert payload to the configured webhook, raising on non-2xx.'''
+
+    async with ClientSession() as session, session.post(
+        url, json=payload, timeout=ClientTimeout(total=_ALERT_WEBHOOK_TIMEOUT_SECONDS),
+    ) as response:
+        response.raise_for_status()
 
 
 def _build_validation_pipeline(
@@ -2282,6 +2293,10 @@ class Launcher:
         self._mark_samplers: list[MarkSampler] = []
         self._book_cache = BookCache()
         self._book_pollers: list[BookPoller] = []
+        self._alert_sink = AlertSink(
+            webhook_url=os.environ.get('PRAXIS_ALERT_WEBHOOK_URL'),
+            post=_post_alert_webhook,
+        )
         self._outcome_queues: dict[str, queue.Queue[NexusTradeOutcome]] = {}
         self._outcome_translator = OutcomeTranslator(fee_rate=_DEFAULT_FEE_RATE)
         self._account_outcome_wiring: dict[str, _AccountOutcomeWiring] = {}
@@ -2734,6 +2749,16 @@ class Launcher:
 
         return web.json_response({'account_id': account.account_id, **report})
 
+    def _build_mode_halt_alert(self, account_id: str) -> Callable[[str], None]:
+        '''Return an on-halt callback that alerts when the account is halted.'''
+
+        def on_halt(source: str) -> None:
+            self._alert_sink.alert(
+                'mode_halted', severity='critical', account_id=account_id, source=source,
+            )
+
+        return on_halt
+
     def _ops_auth_error(self, request: web.Request) -> web.Response | None:
         '''Return an error response when an `/ops` caller is not authorised.
 
@@ -2865,6 +2890,11 @@ class Launcher:
             except Exception:  # noqa: BLE001 - the audit trail is best-effort
                 _log.exception('ops audit event append failed')
 
+        await self._alert_sink.notify(
+            'operator_halt' if halt else 'operator_resume',
+            severity='warning', account_id=account_id, reason=reason,
+        )
+
         return web.json_response(self._ops_status_body(runtime))
 
     async def _ops_cancel_all_handler(self, request: web.Request) -> web.Response:
@@ -2880,6 +2910,11 @@ class Launcher:
 
         account_id = runtime.nexus_config.account_id
         canceled = self._cancel_all_orders(account_id)
+
+        await self._alert_sink.notify(
+            'operator_cancel_all', severity='warning',
+            account_id=account_id, canceled=len(canceled),
+        )
 
         return web.json_response({'account_id': account_id, 'canceled': canceled})
 
@@ -2897,6 +2932,11 @@ class Launcher:
         account_id = runtime.nexus_config.account_id
         canceled = self._cancel_all_orders(account_id)
         closed = await self._close_all_positions(account_id)
+
+        await self._alert_sink.notify(
+            'operator_close_all', severity='warning',
+            account_id=account_id, canceled=len(canceled), closed=len(closed),
+        )
 
         return web.json_response(
             {'account_id': account_id, 'canceled': canceled, 'closed': closed},
@@ -3352,6 +3392,7 @@ class Launcher:
         mode_controller = ModeController(
             state, positions_lock, clock=self._clock,
             risk_thresholds=manifest.risk_controls,
+            on_halt=self._build_mode_halt_alert(inst.account_id),
         )
         mode_controller.reconcile()
         state_store.attach_snapshot_locks(

--- a/praxis/launcher.py
+++ b/praxis/launcher.py
@@ -8,6 +8,8 @@ prices from the control-plane Arrow volume via `ArrowPriceStore`.
 from __future__ import annotations
 
 import asyncio
+import hmac
+import json
 import logging
 import math
 import os
@@ -97,6 +99,8 @@ from praxis.core.domain.trade_abort import TradeAbort
 from praxis.core.domain.events import (
     Event,
     MarkSampled,
+    OperatorHaltRequested,
+    OperatorResumeRequested,
     OutcomeAcked,
     OutcomeDeliveryContextRecorded,
     OutcomeReplayAbandoned,
@@ -2236,6 +2240,8 @@ class Launcher:
         self._outcome_translator = OutcomeTranslator(fee_rate=_DEFAULT_FEE_RATE)
         self._account_outcome_wiring: dict[str, _AccountOutcomeWiring] = {}
         self._account_outcome_wiring_lock = threading.Lock()
+        self._nexus_runtimes: dict[str, _NexusRuntime] = {}
+        self._nexus_runtimes_lock = threading.Lock()
 
     def launch(self) -> None:
         '''Start Praxis + Nexus in one process.
@@ -2602,6 +2608,9 @@ class Launcher:
         app = web.Application()
         app.router.add_get('/healthz', self._healthz_handler)
         app.router.add_get('/metrics', self._metrics_handler)
+        app.router.add_post('/ops/halt', self._ops_halt_handler)
+        app.router.add_post('/ops/resume', self._ops_resume_handler)
+        app.router.add_get('/ops/status', self._ops_status_handler)
         runner = web.AppRunner(app)
         await runner.setup()
         site = web.TCPSite(runner, host='0.0.0.0', port=port)  # noqa: S104
@@ -2674,6 +2683,139 @@ class Launcher:
             return web.json_response({'error': 'metrics_unavailable'}, status=500)
 
         return web.json_response({'account_id': account.account_id, **report})
+
+    def _ops_auth_error(self, request: web.Request) -> web.Response | None:
+        '''Return an error response when an `/ops` caller is not authorised.
+
+        Mutating operator routes are loopback-only and require a bearer
+        token matching `PRAXIS_OPS_TOKEN`; the routes stay disabled while
+        the variable is unset.
+        '''
+
+        if request.remote not in _LOOPBACK_HOSTS:
+            return web.json_response({'error': 'forbidden'}, status=403)
+
+        token = os.environ.get('PRAXIS_OPS_TOKEN')
+
+        if not token:
+            return web.json_response({'error': 'ops_not_configured'}, status=503)
+
+        expected = f'Bearer {token}'
+
+        if not hmac.compare_digest(request.headers.get('Authorization', ''), expected):
+            return web.json_response({'error': 'unauthorized'}, status=401)
+
+        return None
+
+    def _resolve_ops_runtime(self, request: web.Request) -> _NexusRuntime | None:
+        '''Return the running runtime for the request's account, or `None`.
+
+        The `account_id` query parameter selects the account; it defaults
+        to the sole running account when exactly one exists.
+        '''
+
+        with self._nexus_runtimes_lock:
+            runtimes = dict(self._nexus_runtimes)
+
+        account_id = request.query.get('account_id')
+
+        if account_id is None and len(runtimes) == 1:
+            account_id = next(iter(runtimes))
+
+        return runtimes.get(account_id) if account_id is not None else None
+
+    async def _ops_reason(self, request: web.Request, default: str) -> str:
+        raw = await request.text()
+
+        if not raw:
+            return default
+
+        try:
+            body = json.loads(raw)
+        except json.JSONDecodeError:
+            return default
+
+        reason = body.get('reason') if isinstance(body, dict) else None
+
+        return reason if isinstance(reason, str) and reason.strip() else default
+
+    @staticmethod
+    def _ops_status_body(runtime: _NexusRuntime) -> dict[str, Any]:
+        holds = runtime.state.mode_holds
+
+        return {
+            'account_id': runtime.nexus_config.account_id,
+            'mode': runtime.state.mode.mode.value,
+            'trigger': runtime.state.mode.trigger,
+            'holds': {
+                'manual': holds.manual_hold.active,
+                'risk_daily_loss': holds.risk_daily_loss.active,
+                'risk_drawdown': holds.risk_drawdown.active,
+            },
+        }
+
+    async def _ops_status_handler(self, request: web.Request) -> web.Response:
+        auth = self._ops_auth_error(request)
+
+        if auth is not None:
+            return auth
+
+        runtime = self._resolve_ops_runtime(request)
+
+        if runtime is None:
+            return web.json_response({'error': 'unknown_account'}, status=404)
+
+        return web.json_response(self._ops_status_body(runtime))
+
+    async def _ops_halt_handler(self, request: web.Request) -> web.Response:
+        return await self._apply_ops_action(request, halt=True)
+
+    async def _ops_resume_handler(self, request: web.Request) -> web.Response:
+        return await self._apply_ops_action(request, halt=False)
+
+    async def _apply_ops_action(self, request: web.Request, *, halt: bool) -> web.Response:
+        auth = self._ops_auth_error(request)
+
+        if auth is not None:
+            return auth
+
+        runtime = self._resolve_ops_runtime(request)
+
+        if runtime is None:
+            return web.json_response({'error': 'unknown_account'}, status=404)
+
+        account_id = runtime.nexus_config.account_id
+        reason = await self._ops_reason(
+            request, 'operator halt' if halt else 'operator resume',
+        )
+
+        if halt:
+            runtime.mode_controller.set_manual_halt(reason)
+            event: Event = OperatorHaltRequested(
+                account_id=account_id, timestamp=self._clock(), reason=reason,
+            )
+
+        else:
+            runtime.mode_controller.clear_manual_halt()
+            event = OperatorResumeRequested(
+                account_id=account_id, timestamp=self._clock(), reason=reason,
+            )
+
+        try:
+            runtime.state_store.append_mutation(runtime.state)
+        except Exception:  # noqa: BLE001 - a halt that is not durable must fail loudly
+            _log.exception('ops action failed to persist')
+            return web.json_response({'error': 'persist_failed'}, status=500)
+
+        if self._event_spine is not None:
+            try:
+                await self._event_spine.append(
+                    event, epoch_id=self._trading_config.epoch_id,
+                )
+            except Exception:  # noqa: BLE001 - the audit trail is best-effort
+                _log.exception('ops audit event append failed')
+
+        return web.json_response(self._ops_status_body(runtime))
 
     def _start_mark_samplers(self) -> None:
         '''Start one paper-metrics mark sampler per account on the launcher loop.
@@ -2854,11 +2996,16 @@ class Launcher:
 
         try:
             runtime = self._build_nexus_runtime(inst, outcome_queue)
+            with self._nexus_runtimes_lock:
+                self._nexus_runtimes[inst.account_id] = runtime
             self._start_nexus_loops(runtime)
 
             _log.info('nexus instance running', extra={'account_id': inst.account_id})
 
             self._stop_event.wait()
+
+            with self._nexus_runtimes_lock:
+                self._nexus_runtimes.pop(inst.account_id, None)
 
             runtime.health_loop.stop()
             runtime.mtm_loop.stop()

--- a/praxis/launcher.py
+++ b/praxis/launcher.py
@@ -515,6 +515,22 @@ def _build_platform_snapshot_provider(
     return provider
 
 
+def _make_book_fetch(
+    venue_adapter: VenueAdapter, symbol: str,
+) -> Callable[[], Awaitable[OrderBookSnapshot]]:
+    '''Bind a zero-arg top-of-book fetch for one symbol.
+
+    Binding the symbol in this factory keeps each poller's `fetch` a
+    zero-arg callable (as `BookPoller` expects) and avoids the loop-variable
+    late-binding that an inline closure over the loop `account` would hit.
+    '''
+
+    def fetch() -> Awaitable[OrderBookSnapshot]:
+        return venue_adapter.query_order_book(symbol, limit=_BOOK_POLL_DEPTH_LEVELS)
+
+    return fetch
+
+
 def _default_price_snapshot(_context: ValidationRequestContext) -> PriceCheckSnapshot | None:
     '''Return `None`; MMVP `PriceStageLimits` are all unset.'''
 
@@ -3155,12 +3171,10 @@ class Launcher:
 
         try:
             for account in self._paper_account_map().values():
-
-                def fetch(symbol: str = account.symbol) -> Awaitable[OrderBookSnapshot]:
-                    return venue_adapter.query_order_book(symbol, limit=_BOOK_POLL_DEPTH_LEVELS)
-
                 poller = BookPoller(
-                    symbol=account.symbol, fetch=fetch, cache=self._book_cache,
+                    symbol=account.symbol,
+                    fetch=_make_book_fetch(venue_adapter, account.symbol),
+                    cache=self._book_cache,
                     clock=self._clock, interval_seconds=_DEFAULT_BOOK_POLL_INTERVAL_SECONDS,
                 )
                 pollers.append(poller)

--- a/praxis/launcher.py
+++ b/praxis/launcher.py
@@ -417,10 +417,56 @@ def _default_health_snapshot() -> HealthStageSnapshot:
     )
 
 
-def _default_platform_snapshot() -> PlatformLimitsStageSnapshot:
-    '''Return an empty `PlatformLimitsStageSnapshot` for MMVP defaults.'''
+def _default_platform_snapshot(
+    _context: ValidationRequestContext,
+) -> PlatformLimitsStageSnapshot:
+    '''Return an empty `PlatformLimitsStageSnapshot` (MMVP-lenient default).'''
 
     return PlatformLimitsStageSnapshot()
+
+
+def _projected_position(
+    positions: dict[str, Position],
+    context: ValidationRequestContext,
+) -> Decimal:
+    '''Return the account's projected base position for the context's order.
+
+    Sums current open positions in the order's symbol (long positive, short
+    negative) and applies the pending order's signed size, so the
+    platform-limits stage gates the position the order would leave, not the
+    position before it. Floored at zero.
+    '''
+
+    current = sum(
+        (position.size if position.side is OrderSide.BUY else -position.size
+         for position in positions.values() if position.symbol == context.symbol),
+        _ZERO,
+    )
+    delta = context.order_size or _ZERO
+
+    if context.order_side is OrderSide.SELL:
+        delta = -delta
+
+    projected = current + delta
+
+    return projected if projected > _ZERO else _ZERO
+
+
+def _build_platform_snapshot_provider(
+    positions: dict[str, Position],
+) -> Callable[[ValidationRequestContext], PlatformLimitsStageSnapshot]:
+    '''Return a provider that projects the account position for each order.
+
+    Args:
+        positions: The account's live open positions keyed by trade_id.
+    '''
+
+    def provider(context: ValidationRequestContext) -> PlatformLimitsStageSnapshot:
+        return PlatformLimitsStageSnapshot(
+            projected_position=_projected_position(positions, context),
+        )
+
+    return provider
 
 
 def _default_price_snapshot() -> PriceCheckSnapshot | None:
@@ -467,7 +513,7 @@ def _build_validation_pipeline(
     health_snapshot_provider: Callable[[], HealthStageSnapshot] = (
         _default_health_snapshot
     ),
-    platform_snapshot_provider: Callable[[], PlatformLimitsStageSnapshot] = (
+    platform_snapshot_provider: Callable[[ValidationRequestContext], PlatformLimitsStageSnapshot] = (
         _default_platform_snapshot
     ),
     price_snapshot_provider: Callable[[], PriceCheckSnapshot | None] = (
@@ -507,8 +553,9 @@ def _build_validation_pipeline(
             mutable `CapitalState` from `sequencer.instance_state.capital`.
         health_snapshot_provider: Callable returning the current health
             snapshot. Defaults to a neutral-healthy snapshot.
-        platform_snapshot_provider: Callable returning the current
-            platform-limits snapshot. Defaults to an empty snapshot.
+        platform_snapshot_provider: Callable returning the platform-limits
+            snapshot for a request context, used to project the order's
+            resulting position. Defaults to an empty snapshot.
         price_snapshot_provider: Callable returning the current
             price-check snapshot. Defaults to `None`.
         platform_limits: Operator-configured platform caps for the
@@ -556,7 +603,7 @@ def _build_validation_pipeline(
         return validate_platform_limits_stage(
             context,
             platform_limits,
-            platform_snapshot_provider(),
+            platform_snapshot_provider(context),
         )
 
     validators: dict[ValidationStage, StageValidator] = {
@@ -2902,8 +2949,10 @@ class Launcher:
         capital_controller.reconcile_at_boot(positions=state.positions.values())
         pipeline = _build_validation_pipeline(
             nexus_instance_config, capital_controller,
+            platform_snapshot_provider=_build_platform_snapshot_provider(state.positions),
             platform_limits=PlatformLimitsStageLimits(
                 max_order_notional=_env_positive_decimal('PRAXIS_MAX_ORDER_NOTIONAL'),
+                max_position=_env_positive_decimal('PRAXIS_MAX_POSITION'),
             ),
             clock=self._clock,
         )

--- a/praxis/launcher.py
+++ b/praxis/launcher.py
@@ -20,7 +20,7 @@ import uuid
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
@@ -429,6 +429,37 @@ def _default_price_snapshot() -> PriceCheckSnapshot | None:
     return None
 
 
+def _env_positive_decimal(name: str) -> Decimal | None:
+    '''Return a positive finite `Decimal` from environment variable `name`.
+
+    Args:
+        name: Environment variable holding the threshold.
+
+    Returns:
+        The parsed `Decimal`, or `None` when the variable is unset or empty.
+
+    Raises:
+        ValueError: The variable is set but is not a positive finite decimal.
+    '''
+
+    raw = os.environ.get(name)
+
+    if not raw:
+        return None
+
+    try:
+        value = Decimal(raw)
+    except InvalidOperation as exc:
+        msg = f'{name} must be a decimal, got {raw!r}'
+        raise ValueError(msg) from exc
+
+    if not value.is_finite() or value <= _ZERO:
+        msg = f'{name} must be a positive finite decimal, got {raw!r}'
+        raise ValueError(msg)
+
+    return value
+
+
 def _build_validation_pipeline(
     nexus_config: NexusInstanceConfig,
     capital_controller: CapitalController,
@@ -442,6 +473,7 @@ def _build_validation_pipeline(
     price_snapshot_provider: Callable[[], PriceCheckSnapshot | None] = (
         _default_price_snapshot
     ),
+    platform_limits: PlatformLimitsStageLimits | None = None,
     clock: Callable[[], datetime] = _utc_now,
 ) -> ValidationPipeline:
     '''Build a six-stage `ValidationPipeline` for one account.
@@ -451,13 +483,15 @@ def _build_validation_pipeline(
     snapshot, platform-limits snapshot, price-check snapshot) is read on
     every call via the supplied providers.
 
-    MMVP defaults are deliberately lenient: `RiskStageLimits`,
-    `PlatformLimitsStageLimits`, and `HealthStagePolicy` are constructed
-    with all thresholds unset so each stage allows every action;
-    `PriceStageLimits` is derived from `nexus_config` and inherits the
-    same all-unset posture from `_build_nexus_instance_config`.
-    Operator-supplied limits are dialed in pre-live by passing a
-    pre-configured `nexus_config` and richer snapshot providers.
+    MMVP defaults are deliberately lenient: `RiskStageLimits` and
+    `HealthStagePolicy` are constructed with all thresholds unset so each
+    stage allows every action, and `PriceStageLimits` is derived from
+    `nexus_config` and inherits the same all-unset posture from
+    `_build_nexus_instance_config`. `PlatformLimitsStageLimits` is supplied
+    by the caller (empty by default), so operator-configured platform caps
+    such as `max_order_notional` are enforced when set. Operator-supplied
+    limits are dialed in pre-live by passing configured limits and richer
+    snapshot providers.
 
     Intake hooks are built once via `build_default_intake_hooks` so the
     duplicate-order window state is preserved across ticks. Both
@@ -477,6 +511,8 @@ def _build_validation_pipeline(
             platform-limits snapshot. Defaults to an empty snapshot.
         price_snapshot_provider: Callable returning the current
             price-check snapshot. Defaults to `None`.
+        platform_limits: Operator-configured platform caps for the
+            platform-limits stage. Defaults to an empty (all-unset) limit set.
         clock: Source of UTC time for the duplicate-order and order-rate
             intake hooks; a replay run injects its cursor so these gate
             on simulated time rather than wall time.
@@ -488,7 +524,7 @@ def _build_validation_pipeline(
     intake_hooks = build_default_intake_hooks(nexus_config, now_fn=clock)
     risk_limits = RiskStageLimits()
     price_limits = build_price_stage_limits_from_config(nexus_config)
-    platform_limits = PlatformLimitsStageLimits()
+    platform_limits = platform_limits if platform_limits is not None else PlatformLimitsStageLimits()
     health_policy = HealthStagePolicy()
 
     def intake(context: ValidationRequestContext) -> ValidationDecision:
@@ -2865,7 +2901,11 @@ class Launcher:
         capital_controller = CapitalController(state.capital, clock=self._clock)
         capital_controller.reconcile_at_boot(positions=state.positions.values())
         pipeline = _build_validation_pipeline(
-            nexus_instance_config, capital_controller, clock=self._clock,
+            nexus_instance_config, capital_controller,
+            platform_limits=PlatformLimitsStageLimits(
+                max_order_notional=_env_positive_decimal('PRAXIS_MAX_ORDER_NOTIONAL'),
+            ),
+            clock=self._clock,
         )
         positions_lock = threading.Lock()
         command_registry_lock = threading.Lock()

--- a/praxis/launcher.py
+++ b/praxis/launcher.py
@@ -2841,11 +2841,16 @@ class Launcher:
 
         return None
 
-    def _resolve_ops_runtime(self, request: web.Request) -> _NexusRuntime | None:
-        '''Return the running runtime for the request's account, or `None`.
+    def _resolve_ops_runtime(
+        self, request: web.Request,
+    ) -> tuple[_NexusRuntime | None, web.Response | None]:
+        '''Resolve the request's runtime, or an error response.
 
         The `account_id` query parameter selects the account; it defaults
-        to the sole running account when exactly one exists.
+        to the sole running account when exactly one exists. When it is
+        omitted and more than one account is running the request is
+        ambiguous — a 400 `account_id_required` rather than a misleading
+        404 `unknown_account`.
         '''
 
         with self._nexus_runtimes_lock:
@@ -2853,10 +2858,24 @@ class Launcher:
 
         account_id = request.query.get('account_id')
 
-        if account_id is None and len(runtimes) == 1:
-            account_id = next(iter(runtimes))
+        if account_id is None:
 
-        return runtimes.get(account_id) if account_id is not None else None
+            if len(runtimes) == 1:
+                return next(iter(runtimes.values())), None
+
+            if len(runtimes) > 1:
+                return None, web.json_response(
+                    {'error': 'account_id_required', 'known': sorted(runtimes)}, status=400,
+                )
+
+            return None, web.json_response({'error': 'unknown_account'}, status=404)
+
+        runtime = runtimes.get(account_id)
+
+        if runtime is None:
+            return None, web.json_response({'error': 'unknown_account'}, status=404)
+
+        return runtime, None
 
     async def _ops_reason(self, request: web.Request, default: str) -> str:
         raw = await request.text()
@@ -2894,10 +2913,10 @@ class Launcher:
         if auth is not None:
             return auth
 
-        runtime = self._resolve_ops_runtime(request)
+        runtime, error = self._resolve_ops_runtime(request)
 
-        if runtime is None:
-            return web.json_response({'error': 'unknown_account'}, status=404)
+        if error is not None:
+            return error
 
         return web.json_response(self._ops_status_body(runtime))
 
@@ -2913,10 +2932,10 @@ class Launcher:
         if auth is not None:
             return auth
 
-        runtime = self._resolve_ops_runtime(request)
+        runtime, error = self._resolve_ops_runtime(request)
 
-        if runtime is None:
-            return web.json_response({'error': 'unknown_account'}, status=404)
+        if error is not None:
+            return error
 
         account_id = runtime.nexus_config.account_id
         reason = await self._ops_reason(
@@ -2962,10 +2981,10 @@ class Launcher:
         if auth is not None:
             return auth
 
-        runtime = self._resolve_ops_runtime(request)
+        runtime, error = self._resolve_ops_runtime(request)
 
-        if runtime is None:
-            return web.json_response({'error': 'unknown_account'}, status=404)
+        if error is not None:
+            return error
 
         account_id = runtime.nexus_config.account_id
 
@@ -2988,10 +3007,10 @@ class Launcher:
         if auth is not None:
             return auth
 
-        runtime = self._resolve_ops_runtime(request)
+        runtime, error = self._resolve_ops_runtime(request)
 
-        if runtime is None:
-            return web.json_response({'error': 'unknown_account'}, status=404)
+        if error is not None:
+            return error
 
         account_id = runtime.nexus_config.account_id
 

--- a/praxis/launcher.py
+++ b/praxis/launcher.py
@@ -34,6 +34,7 @@ from nexus.core.domain.instance_state import InstanceState
 from nexus.core.domain.position import Position
 from nexus.core.health_evaluator import HealthEvaluator, HealthThresholds
 from nexus.core.health_loop import HealthLoop
+from nexus.core.mode_controller import ModeController
 from nexus.core.mtm_loop import MtmLoop
 from nexus.core.outcome_loop import OutcomeLoop
 from nexus.core.stp_mode import STPMode
@@ -341,6 +342,7 @@ def _build_health_loop(
     account_id: str,
     interval_seconds: float = _DEFAULT_HEALTH_INTERVAL_SECONDS,
     state_store: StateStore | None = None,
+    mode_controller: ModeController | None = None,
 ) -> HealthLoop:
     '''Build a per-account `HealthLoop` wired to Praxis health pulls.
 
@@ -397,6 +399,7 @@ def _build_health_loop(
         state=state,
         interval_seconds=interval_seconds,
         rolling_loss_refresher=rolling_loss_refresher,
+        mode_controller=mode_controller,
     )
 
 
@@ -2103,6 +2106,7 @@ class _NexusRuntime:
     timer_loop: TimerLoop | None
     outcome_loop: OutcomeLoop
     health_loop: HealthLoop
+    mode_controller: ModeController
     snapshot_scheduler: SnapshotScheduler
     mtm_loop: MtmLoop
     unknown_submission_monitor: _UnknownSubmissionMonitor
@@ -2966,6 +2970,7 @@ class Launcher:
             )
             raise RuntimeError(msg)
         state.risk.lock = positions_lock
+        mode_controller = ModeController(state, positions_lock, clock=self._clock)
         state_store.attach_snapshot_locks(
             _build_state_snapshot_locks(state, positions_lock, capital_controller),
         )
@@ -3404,6 +3409,7 @@ class Launcher:
             state=state,
             account_id=inst.account_id,
             state_store=state_store,
+            mode_controller=mode_controller,
         )
 
         snapshot_interval = _positive_float_env(
@@ -3465,6 +3471,7 @@ class Launcher:
             timer_loop=timer_loop,
             outcome_loop=outcome_loop,
             health_loop=health_loop,
+            mode_controller=mode_controller,
             snapshot_scheduler=snapshot_scheduler,
             mtm_loop=mtm_loop,
             unknown_submission_monitor=unknown_submission_monitor,

--- a/praxis/launcher.py
+++ b/praxis/launcher.py
@@ -3224,7 +3224,7 @@ class Launcher:
             if thread.is_alive():
                 _log.warning(
                     'nexus thread did not finish within timeout',
-                    extra={'thread': thread.name},
+                    extra={'thread_name': thread.name},
                 )
 
         if self._trading is not None and self._loop is not None:

--- a/praxis/launcher.py
+++ b/praxis/launcher.py
@@ -280,9 +280,9 @@ def _build_nexus_instance_config(
         msg = (
             f'PRAXIS_BOOK_STALENESS_SECONDS ({book_staleness_max_seconds}) must '
             f'exceed the book poll interval ({_DEFAULT_BOOK_POLL_INTERVAL_SECONDS}s): '
-            f'at or below it the cached book is always older than the limit, so the '
-            f'price stage rejects every order with PRICE_BOOK_STALE and silently '
-            f'stalls trading.'
+            f'at or below it the cached book is frequently older than the limit '
+            f'between polls, so the price stage rejects orders with PRICE_BOOK_STALE '
+            f'often enough to stall trading.'
         )
         raise ValueError(msg)
 
@@ -2819,17 +2819,24 @@ class Launcher:
         '''
 
         def on_halt(source: str) -> None:
-            if self._loop is None:
-                self._alert_sink.alert(
-                    'mode_halted', severity='critical', account_id=account_id, source=source,
-                )
-                return
+            loop = self._loop
 
-            asyncio.run_coroutine_threadsafe(
-                self._alert_sink.notify(
-                    'mode_halted', severity='critical', account_id=account_id, source=source,
-                ),
-                self._loop,
+            if loop is not None and not loop.is_closed():
+
+                try:
+                    asyncio.run_coroutine_threadsafe(
+                        self._alert_sink.notify(
+                            'mode_halted', severity='critical',
+                            account_id=account_id, source=source,
+                        ),
+                        loop,
+                    )
+                    return
+                except RuntimeError:
+                    pass
+
+            self._alert_sink.alert(
+                'mode_halted', severity='critical', account_id=account_id, source=source,
             )
 
         return on_halt

--- a/praxis/launcher.py
+++ b/praxis/launcher.py
@@ -94,7 +94,14 @@ from praxis.command_translator import (
     translate_order_type,
     translate_stp_mode,
 )
-from praxis.core.domain.enums import OrderSide as _PraxisOrderSide, OrderType
+from praxis.core.domain.enums import (
+    ExecutionMode,
+    MakerPreference,
+    OrderSide as _PraxisOrderSide,
+    OrderType,
+    STPMode as _PraxisSTPMode,
+)
+from praxis.core.domain.single_shot_params import SingleShotParams
 from praxis.core.domain.trade_abort import TradeAbort
 from praxis.core.domain.events import (
     Event,
@@ -146,6 +153,7 @@ _DEFAULT_VENUE = 'binance_spot'
 _DEFAULT_FEE_RATE = Decimal('0.001')
 _DEFAULT_SYMBOL = 'BTCUSDT'
 _LOOPBACK_HOSTS = frozenset({'127.0.0.1', '::1'})
+_OPS_CLOSE_TIMEOUT_SECONDS = 60
 
 
 def _utc_now() -> datetime:
@@ -2610,6 +2618,8 @@ class Launcher:
         app.router.add_get('/metrics', self._metrics_handler)
         app.router.add_post('/ops/halt', self._ops_halt_handler)
         app.router.add_post('/ops/resume', self._ops_resume_handler)
+        app.router.add_post('/ops/cancel-all', self._ops_cancel_all_handler)
+        app.router.add_post('/ops/close-all', self._ops_close_all_handler)
         app.router.add_get('/ops/status', self._ops_status_handler)
         runner = web.AppRunner(app)
         await runner.setup()
@@ -2816,6 +2826,105 @@ class Launcher:
                 _log.exception('ops audit event append failed')
 
         return web.json_response(self._ops_status_body(runtime))
+
+    async def _ops_cancel_all_handler(self, request: web.Request) -> web.Response:
+        auth = self._ops_auth_error(request)
+
+        if auth is not None:
+            return auth
+
+        runtime = self._resolve_ops_runtime(request)
+
+        if runtime is None:
+            return web.json_response({'error': 'unknown_account'}, status=404)
+
+        account_id = runtime.nexus_config.account_id
+        canceled = self._cancel_all_orders(account_id)
+
+        return web.json_response({'account_id': account_id, 'canceled': canceled})
+
+    async def _ops_close_all_handler(self, request: web.Request) -> web.Response:
+        auth = self._ops_auth_error(request)
+
+        if auth is not None:
+            return auth
+
+        runtime = self._resolve_ops_runtime(request)
+
+        if runtime is None:
+            return web.json_response({'error': 'unknown_account'}, status=404)
+
+        account_id = runtime.nexus_config.account_id
+        canceled = self._cancel_all_orders(account_id)
+        closed = await self._close_all_positions(account_id)
+
+        return web.json_response(
+            {'account_id': account_id, 'canceled': canceled, 'closed': closed},
+        )
+
+    def _cancel_all_orders(self, account_id: str) -> list[str]:
+        '''Abort every working command for an account; returns the aborted ids.'''
+
+        if self._trading is None:
+            return []
+
+        command_ids = {
+            order.command_id
+            for order in self._trading.execution_manager.get_open_orders(account_id).values()
+        }
+        canceled: list[str] = []
+
+        for command_id in sorted(command_ids):
+
+            try:
+                self._trading.submit_abort(TradeAbort(
+                    command_id=command_id, account_id=account_id,
+                    reason='operator cancel-all', created_at=self._clock(),
+                ))
+            except Exception:  # noqa: BLE001 - one failed abort must not stop the rest
+                _log.warning('cancel-all skipped a command', extra={'command_id': command_id})
+            else:
+                canceled.append(command_id)
+
+        return canceled
+
+    async def _close_all_positions(self, account_id: str) -> list[dict[str, str]]:
+        '''Submit a market exit for every open position; returns per-trade results.'''
+
+        if self._trading is None:
+            return []
+
+        closed: list[dict[str, str]] = []
+
+        for (trade_id, _acct), position in self._trading.pull_positions(account_id).items():
+            net = position.qty
+
+            if net <= _ZERO:
+                continue
+
+            exit_side = (
+                _PraxisOrderSide.SELL
+                if position.side is _PraxisOrderSide.BUY
+                else _PraxisOrderSide.BUY
+            )
+
+            try:
+                command_id = await self._trading.submit_command(
+                    trade_id=trade_id, account_id=account_id, symbol=position.symbol,
+                    side=exit_side, qty=net, quote_qty=None,
+                    order_type=OrderType.MARKET, execution_mode=ExecutionMode.SINGLE_SHOT,
+                    execution_params=SingleShotParams(),
+                    timeout=_OPS_CLOSE_TIMEOUT_SECONDS, reference_price=None,
+                    maker_preference=MakerPreference.NO_PREFERENCE, stp_mode=_PraxisSTPMode.NONE,
+                    created_at=self._clock(),
+                )
+            except Exception:  # noqa: BLE001 - one failed exit must not stop the rest
+                _log.exception('close-all failed to submit an exit', extra={'trade_id': trade_id})
+                closed.append({'trade_id': trade_id, 'error': 'submit_failed'})
+            else:
+                closed.append({'trade_id': trade_id, 'command_id': command_id, 'qty': str(net)})
+
+        return closed
 
     def _start_mark_samplers(self) -> None:
         '''Start one paper-metrics mark sampler per account on the launcher loop.

--- a/praxis/launcher.py
+++ b/praxis/launcher.py
@@ -2433,6 +2433,7 @@ class Launcher:
             venue_adapter=self._venue_adapter,
             bootstrap_filter_symbols=frozenset({_DEFAULT_SYMBOL}),
             clock=self._clock,
+            max_slippage_bps=_env_positive_decimal('PRAXIS_MAX_SLIPPAGE_BPS'),
         )
 
         for inst in self._instances:

--- a/praxis/launcher.py
+++ b/praxis/launcher.py
@@ -158,6 +158,7 @@ _DEFAULT_SYMBOL = 'BTCUSDT'
 _LOOPBACK_HOSTS = frozenset({'127.0.0.1', '::1'})
 _OPS_CLOSE_TIMEOUT_SECONDS = 60
 _DEFAULT_BOOK_POLL_INTERVAL_SECONDS = 2.0
+_BOOK_POLL_DEPTH_LEVELS = 5
 _ALERT_WEBHOOK_TIMEOUT_SECONDS = 5
 
 
@@ -2785,9 +2786,9 @@ class Launcher:
     def _ops_auth_error(self, request: web.Request) -> web.Response | None:
         '''Return an error response when an `/ops` caller is not authorised.
 
-        Mutating operator routes are loopback-only and require a bearer
-        token matching `PRAXIS_OPS_TOKEN`; the routes stay disabled while
-        the variable is unset.
+        Every `/ops` route — including read-only `status` — is loopback-only
+        and requires a bearer token matching `PRAXIS_OPS_TOKEN`; the routes
+        stay disabled while the variable is unset.
         '''
 
         if request.remote not in _LOOPBACK_HOSTS:
@@ -3156,7 +3157,7 @@ class Launcher:
             for account in self._paper_account_map().values():
 
                 def fetch(symbol: str = account.symbol) -> Awaitable[OrderBookSnapshot]:
-                    return venue_adapter.query_order_book(symbol)
+                    return venue_adapter.query_order_book(symbol, limit=_BOOK_POLL_DEPTH_LEVELS)
 
                 poller = BookPoller(
                     symbol=account.symbol, fetch=fetch, cache=self._book_cache,

--- a/praxis/launcher.py
+++ b/praxis/launcher.py
@@ -270,6 +270,21 @@ def _build_nexus_instance_config(
         spec.strategy_id: spec.capital_pct for spec in manifest.strategies
     }
 
+    book_staleness_max_seconds = _env_positive_int('PRAXIS_BOOK_STALENESS_SECONDS')
+
+    if (
+        book_staleness_max_seconds is not None
+        and book_staleness_max_seconds <= _DEFAULT_BOOK_POLL_INTERVAL_SECONDS
+    ):
+        msg = (
+            f'PRAXIS_BOOK_STALENESS_SECONDS ({book_staleness_max_seconds}) must '
+            f'exceed the book poll interval ({_DEFAULT_BOOK_POLL_INTERVAL_SECONDS}s): '
+            f'at or below it the cached book is always older than the limit, so the '
+            f'price stage rejects every order with PRICE_BOOK_STALE and silently '
+            f'stalls trading.'
+        )
+        raise ValueError(msg)
+
     return NexusInstanceConfig(
         account_id=praxis_inst.account_id,
         venue=_DEFAULT_VENUE,
@@ -277,7 +292,7 @@ def _build_nexus_instance_config(
         stp_mode=STPMode.CANCEL_TAKER,
         capital_pct=capital_pct,
         max_spread_bps=_env_positive_decimal('PRAXIS_MAX_SPREAD_BPS'),
-        book_staleness_max_seconds=_env_positive_int('PRAXIS_BOOK_STALENESS_SECONDS'),
+        book_staleness_max_seconds=book_staleness_max_seconds,
     )
 
 
@@ -476,16 +491,24 @@ def _projected_position(
 
 def _build_platform_snapshot_provider(
     positions: dict[str, Position],
+    positions_lock: threading.Lock,
 ) -> Callable[[ValidationRequestContext], PlatformLimitsStageSnapshot]:
     '''Return a provider that projects the account position for each order.
 
     Args:
         positions: The account's live open positions keyed by trade_id.
+        positions_lock: Guards `positions` against concurrent OutcomeLoop
+            deletes; the provider runs at validation time on the strategy
+            thread, outside the validator's lock, so it snapshots under this
+            lock to avoid a `dictionary changed size during iteration` race.
     '''
 
     def provider(context: ValidationRequestContext) -> PlatformLimitsStageSnapshot:
+        with positions_lock:
+            snapshot = dict(positions)
+
         return PlatformLimitsStageSnapshot(
-            projected_position=_projected_position(positions, context),
+            projected_position=_projected_position(snapshot, context),
         )
 
     return provider
@@ -3370,9 +3393,12 @@ class Launcher:
         nexus_instance_config = _build_nexus_instance_config(inst, manifest)
         capital_controller = CapitalController(state.capital, clock=self._clock)
         capital_controller.reconcile_at_boot(positions=state.positions.values())
+        positions_lock = threading.Lock()
         pipeline = _build_validation_pipeline(
             nexus_instance_config, capital_controller,
-            platform_snapshot_provider=_build_platform_snapshot_provider(state.positions),
+            platform_snapshot_provider=_build_platform_snapshot_provider(
+                state.positions, positions_lock,
+            ),
             platform_limits=PlatformLimitsStageLimits(
                 max_order_notional=_env_positive_decimal('PRAXIS_MAX_ORDER_NOTIONAL'),
                 max_position=_env_positive_decimal('PRAXIS_MAX_POSITION'),
@@ -3380,7 +3406,6 @@ class Launcher:
             price_snapshot_provider=self._build_price_snapshot_provider(),
             clock=self._clock,
         )
-        positions_lock = threading.Lock()
         command_registry_lock = threading.Lock()
         if not hasattr(state.risk, 'lock'):
             msg = (

--- a/praxis/launcher.py
+++ b/praxis/launcher.py
@@ -3168,12 +3168,13 @@ class Launcher:
             return
 
         pollers: list[BookPoller] = []
+        symbols = {account.symbol for account in self._paper_account_map().values()}
 
         try:
-            for account in self._paper_account_map().values():
+            for symbol in sorted(symbols):
                 poller = BookPoller(
-                    symbol=account.symbol,
-                    fetch=_make_book_fetch(venue_adapter, account.symbol),
+                    symbol=symbol,
+                    fetch=_make_book_fetch(venue_adapter, symbol),
                     cache=self._book_cache,
                     clock=self._clock, interval_seconds=_DEFAULT_BOOK_POLL_INTERVAL_SECONDS,
                 )

--- a/praxis/launcher.py
+++ b/praxis/launcher.py
@@ -2809,11 +2809,27 @@ class Launcher:
         return web.json_response({'account_id': account.account_id, **report})
 
     def _build_mode_halt_alert(self, account_id: str) -> Callable[[str], None]:
-        '''Return an on-halt callback that alerts when the account is halted.'''
+        '''Return an on-halt callback that alerts when the account is halted.
+
+        The callback fires on the ModeController's thread, not the event
+        loop, so it schedules `AlertSink.notify` (log + webhook) onto the
+        loop when one is available and falls back to the synchronous
+        log-only `alert` otherwise, keeping webhook delivery best-effort
+        without double-logging.
+        '''
 
         def on_halt(source: str) -> None:
-            self._alert_sink.alert(
-                'mode_halted', severity='critical', account_id=account_id, source=source,
+            if self._loop is None:
+                self._alert_sink.alert(
+                    'mode_halted', severity='critical', account_id=account_id, source=source,
+                )
+                return
+
+            asyncio.run_coroutine_threadsafe(
+                self._alert_sink.notify(
+                    'mode_halted', severity='critical', account_id=account_id, source=source,
+                ),
+                self._loop,
             )
 
         return on_halt
@@ -2918,6 +2934,8 @@ class Launcher:
         if error is not None:
             return error
 
+        assert runtime is not None
+
         return web.json_response(self._ops_status_body(runtime))
 
     async def _ops_halt_handler(self, request: web.Request) -> web.Response:
@@ -2936,6 +2954,8 @@ class Launcher:
 
         if error is not None:
             return error
+
+        assert runtime is not None
 
         account_id = runtime.nexus_config.account_id
         reason = await self._ops_reason(
@@ -2986,6 +3006,8 @@ class Launcher:
         if error is not None:
             return error
 
+        assert runtime is not None
+
         account_id = runtime.nexus_config.account_id
 
         try:
@@ -3011,6 +3033,8 @@ class Launcher:
 
         if error is not None:
             return error
+
+        assert runtime is not None
 
         account_id = runtime.nexus_config.account_id
 
@@ -3397,6 +3421,10 @@ class Launcher:
 
         except Exception:  # noqa: BLE001 - top-level catch for thread, must not propagate
             _log.exception('nexus instance failed', extra={'account_id': inst.account_id})
+
+            with self._nexus_runtimes_lock:
+                self._nexus_runtimes.pop(inst.account_id, None)
+
             self._stop_event.set()
 
     def _build_nexus_runtime(

--- a/praxis/launcher.py
+++ b/praxis/launcher.py
@@ -274,6 +274,8 @@ def _build_nexus_instance_config(
         duplicate_window_ms=_DEFAULT_DUPLICATE_WINDOW_MS,
         stp_mode=STPMode.CANCEL_TAKER,
         capital_pct=capital_pct,
+        max_spread_bps=_env_positive_decimal('PRAXIS_MAX_SPREAD_BPS'),
+        book_staleness_max_seconds=_env_positive_int('PRAXIS_BOOK_STALENESS_SECONDS'),
     )
 
 
@@ -519,6 +521,37 @@ def _env_positive_decimal(name: str) -> Decimal | None:
 
     if not value.is_finite() or value <= _ZERO:
         msg = f'{name} must be a positive finite decimal, got {raw!r}'
+        raise ValueError(msg)
+
+    return value
+
+
+def _env_positive_int(name: str) -> int | None:
+    '''Return a positive integer from environment variable `name`.
+
+    Args:
+        name: Environment variable holding the value.
+
+    Returns:
+        The parsed integer, or `None` when the variable is unset or empty.
+
+    Raises:
+        ValueError: The variable is set but is not a positive integer.
+    '''
+
+    raw = os.environ.get(name)
+
+    if not raw:
+        return None
+
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        msg = f'{name} must be an integer, got {raw!r}'
+        raise ValueError(msg) from exc
+
+    if value <= 0:
+        msg = f'{name} must be a positive integer, got {raw!r}'
         raise ValueError(msg)
 
     return value

--- a/praxis/trading.py
+++ b/praxis/trading.py
@@ -88,6 +88,7 @@ class Trading:
         venue_adapter: VenueAdapter | None = None,
         bootstrap_filter_symbols: frozenset[str] = frozenset(),
         clock: Callable[[], datetime] = _utc_now,
+        max_slippage_bps: Decimal | None = None,
     ) -> None:
         '''Compose core trading dependencies and manager-facing facade.
 
@@ -127,6 +128,7 @@ class Trading:
             venue_adapter=self._venue_adapter,
             on_trade_outcome=config.on_trade_outcome,
             clock=clock,
+            max_slippage_bps=max_slippage_bps,
         )
         self._inbound = TradingInbound(
             execution_manager=self._execution_manager,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum-praxis"
-version = "0.91.0"
+version = "0.92.0"
 description = "Execution system for Vaquum — Trading sub-system + Account sub-system."
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 ]
 license = { text = "MIT" }
 requires-python = ">=3.12"
-dependencies = ["structlog>=24.1", "orjson>=3.10", "aiosqlite>=0.20", "aiohttp>=3.10", "polars>=1.0", "numpy>=1.26", "vaquum-nexus @ git+https://github.com/Vaquum/Nexus@03620eb35a53706821be0b3353ab4cc4db40c990"]
+dependencies = ["structlog>=24.1", "orjson>=3.10", "aiosqlite>=0.20", "aiohttp>=3.10", "polars>=1.0", "numpy>=1.26", "vaquum-nexus @ git+https://github.com/Vaquum/Nexus@f74514a814fd58fae0b9d149d0b4e2688d272d61"]
 
 [project.optional-dependencies]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 ]
 license = { text = "MIT" }
 requires-python = ">=3.12"
-dependencies = ["structlog>=24.1", "orjson>=3.10", "aiosqlite>=0.20", "aiohttp>=3.10", "polars>=1.0", "numpy>=1.26", "vaquum-nexus @ git+https://github.com/Vaquum/Nexus@f74514a814fd58fae0b9d149d0b4e2688d272d61"]
+dependencies = ["structlog>=24.1", "orjson>=3.10", "aiosqlite>=0.20", "aiohttp>=3.10", "polars>=1.0", "numpy>=1.26", "vaquum-nexus @ git+https://github.com/Vaquum/Nexus@2817a70e60a0fcdefd6323349ebfbc2e732769fa"]
 
 [project.optional-dependencies]
 dev = [

--- a/tests/test_alert_sink.py
+++ b/tests/test_alert_sink.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from decimal import Decimal
 from typing import Any
 
 import pytest
@@ -74,3 +75,16 @@ async def test_notify_normalizes_invalid_severity_in_webhook_payload() -> None:
     await sink.notify('x', severity='bogus', account_id='a1')
 
     assert posted == [{'event': 'x', 'severity': 'warning', 'account_id': 'a1'}]
+
+
+@pytest.mark.asyncio
+async def test_notify_stringifies_non_json_detail_in_webhook_payload() -> None:
+    posted: list[dict[str, Any]] = []
+
+    async def post(_url: str, payload: dict[str, Any]) -> None:
+        posted.append(payload)
+
+    sink = AlertSink(webhook_url='http://hook', post=post)
+    await sink.notify('x', severity='warning', amount=Decimal('12.5'))
+
+    assert posted == [{'event': 'x', 'severity': 'warning', 'amount': '12.5'}]

--- a/tests/test_alert_sink.py
+++ b/tests/test_alert_sink.py
@@ -61,3 +61,16 @@ async def test_notify_swallows_webhook_failure(caplog: pytest.LogCaptureFixture)
         await sink.notify('x')
 
     assert any('alert webhook failed' in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_notify_normalizes_invalid_severity_in_webhook_payload() -> None:
+    posted: list[dict[str, Any]] = []
+
+    async def post(_url: str, payload: dict[str, Any]) -> None:
+        posted.append(payload)
+
+    sink = AlertSink(webhook_url='http://hook', post=post)
+    await sink.notify('x', severity='bogus', account_id='a1')
+
+    assert posted == [{'event': 'x', 'severity': 'warning', 'account_id': 'a1'}]

--- a/tests/test_alert_sink.py
+++ b/tests/test_alert_sink.py
@@ -1,0 +1,63 @@
+'''Tests for the AlertSink.'''
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+
+from praxis.infrastructure.alert_sink import AlertSink
+
+
+def test_alert_emits_structured_log_line(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.WARNING):
+        AlertSink().alert('mode_halted', severity='critical', account_id='a1')
+
+    assert any(
+        'ALERT event=mode_halted' in record.message and 'severity=critical' in record.message
+        for record in caplog.records
+    )
+
+
+def test_invalid_severity_coerced_to_warning(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.WARNING):
+        AlertSink().alert('x', severity='bogus')
+
+    assert any('severity=warning' in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_notify_posts_to_webhook() -> None:
+    posted: list[tuple[str, dict[str, Any]]] = []
+
+    async def post(url: str, payload: dict[str, Any]) -> None:
+        posted.append((url, payload))
+
+    sink = AlertSink(webhook_url='http://hook', post=post)
+    await sink.notify('breaker_tripped', severity='critical', account_id='a1')
+
+    assert posted == [
+        ('http://hook', {'event': 'breaker_tripped', 'severity': 'critical', 'account_id': 'a1'}),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_notify_log_only_without_webhook(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.WARNING):
+        await AlertSink().notify('x')
+
+    assert any('ALERT event=x' in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_notify_swallows_webhook_failure(caplog: pytest.LogCaptureFixture) -> None:
+    async def post(_url: str, _payload: dict[str, Any]) -> None:
+        raise RuntimeError('hook down')
+
+    sink = AlertSink(webhook_url='http://hook', post=post)
+
+    with caplog.at_level(logging.WARNING):
+        await sink.notify('x')
+
+    assert any('alert webhook failed' in record.message for record in caplog.records)

--- a/tests/test_book_cache.py
+++ b/tests/test_book_cache.py
@@ -1,0 +1,92 @@
+'''Tests for the order book cache, price-snapshot builder, and poller.'''
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+
+from praxis.infrastructure.book_cache import BookCache, build_price_snapshot
+from praxis.infrastructure.book_poller import BookPoller
+from praxis.infrastructure.venue_adapter import OrderBookLevel, OrderBookSnapshot
+
+_NOW = datetime(2026, 1, 1, 0, 0, 1, tzinfo=UTC)
+_FETCHED = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+
+
+def _book(bid: str, ask: str) -> OrderBookSnapshot:
+    return OrderBookSnapshot(
+        bids=(OrderBookLevel(price=Decimal(bid), qty=Decimal('1')),),
+        asks=(OrderBookLevel(price=Decimal(ask), qty=Decimal('1')),),
+        last_update_id=1,
+    )
+
+
+def test_build_price_snapshot_returns_none_when_empty():
+    assert build_price_snapshot(BookCache(), 'BTCUSDT', _NOW) is None
+
+
+def test_build_price_snapshot_computes_spread_and_timestamps():
+    cache = BookCache()
+    cache.update('BTCUSDT', _book('100', '101'), _FETCHED)
+
+    snapshot = build_price_snapshot(cache, 'BTCUSDT', _NOW)
+
+    assert snapshot is not None
+    assert snapshot.spread_bps == (Decimal('1') / Decimal('100.5')) * Decimal('10000')
+    assert snapshot.now_ms == int(_NOW.timestamp() * 1000)
+    assert snapshot.book_timestamp_ms == int(_FETCHED.timestamp() * 1000)
+
+
+def test_build_price_snapshot_none_on_crossed_book():
+    cache = BookCache()
+    cache.update('BTCUSDT', _book('101', '100'), _FETCHED)
+
+    assert build_price_snapshot(cache, 'BTCUSDT', _NOW) is None
+
+
+def test_build_price_snapshot_none_on_empty_levels():
+    cache = BookCache()
+    cache.update('BTCUSDT', OrderBookSnapshot(bids=(), asks=(), last_update_id=1), _FETCHED)
+
+    assert build_price_snapshot(cache, 'BTCUSDT', _NOW) is None
+
+
+def test_cache_returns_latest_book():
+    cache = BookCache()
+    cache.update('BTCUSDT', _book('100', '101'), _FETCHED)
+    cache.update('BTCUSDT', _book('200', '201'), _FETCHED)
+
+    cached = cache.get('BTCUSDT')
+
+    assert cached is not None
+    assert cached.snapshot.bids[0].price == Decimal('200')
+
+
+@pytest.mark.asyncio
+async def test_poller_tick_updates_cache():
+    cache = BookCache()
+    book = _book('100', '101')
+
+    async def fetch() -> OrderBookSnapshot:
+        return book
+
+    poller = BookPoller('BTCUSDT', fetch, cache, lambda: _FETCHED, interval_seconds=1.0)
+    await poller.tick_once()
+
+    cached = cache.get('BTCUSDT')
+    assert cached is not None
+    assert cached.snapshot is book
+    assert cached.fetched_at == _FETCHED
+
+
+def test_poller_rejects_bad_interval():
+    with pytest.raises(ValueError, match='interval_seconds must be positive'):
+        BookPoller(
+            'BTCUSDT', _never_fetch, BookCache(), lambda: _FETCHED, interval_seconds=0,
+        )
+
+
+async def _never_fetch() -> OrderBookSnapshot:
+    raise AssertionError('fetch should not be called')

--- a/tests/test_estimate_slippage.py
+++ b/tests/test_estimate_slippage.py
@@ -6,7 +6,7 @@ from decimal import Decimal
 import pytest
 
 from praxis.core.domain.enums import OrderSide
-from praxis.core.estimate_slippage import estimate_slippage
+from praxis.core.estimate_slippage import estimate_slippage, estimate_slippage_for_quote
 from praxis.infrastructure.venue_adapter import OrderBookLevel, OrderBookSnapshot
 
 
@@ -80,3 +80,27 @@ def test_estimate_slippage_partial_depth_logs_warning(
     messages = [r.message for r in caplog.records]
     assert any('book depth insufficient:' in message for message in messages)
     assert any('symbol=BTCUSDT' in message for message in messages)
+
+
+def test_quote_slippage_buy_walks_ask_levels() -> None:
+    book = OrderBookSnapshot(
+        bids=(OrderBookLevel(price=Decimal('100'), qty=Decimal('5')),),
+        asks=(
+            OrderBookLevel(price=Decimal('101'), qty=Decimal('1')),
+            OrderBookLevel(price=Decimal('102'), qty=Decimal('2')),
+        ),
+        last_update_id=1,
+    )
+
+    estimate = estimate_slippage_for_quote(book, Decimal('300'), OrderSide.BUY)
+
+    assert estimate is not None
+    assert estimate.mid_price == Decimal('100.5')
+    assert estimate.simulated_vwap > Decimal('101')
+    assert estimate.slippage_estimate_bps > Decimal('0')
+
+
+def test_quote_slippage_none_on_empty_book() -> None:
+    book = OrderBookSnapshot(bids=(), asks=(), last_update_id=1)
+
+    assert estimate_slippage_for_quote(book, Decimal('100'), OrderSide.BUY) is None

--- a/tests/test_estimate_slippage.py
+++ b/tests/test_estimate_slippage.py
@@ -104,3 +104,13 @@ def test_quote_slippage_none_on_empty_book() -> None:
     book = OrderBookSnapshot(bids=(), asks=(), last_update_id=1)
 
     assert estimate_slippage_for_quote(book, Decimal('100'), OrderSide.BUY) is None
+
+
+def test_estimate_returns_none_for_a_crossed_book() -> None:
+    book = OrderBookSnapshot(
+        bids=(OrderBookLevel(price=Decimal('100'), qty=Decimal('5')),),
+        asks=(OrderBookLevel(price=Decimal('99'), qty=Decimal('5')),),
+        last_update_id=1,
+    )
+
+    assert estimate_slippage_for_quote(book, Decimal('50'), OrderSide.BUY) is None

--- a/tests/test_event_spine.py
+++ b/tests/test_event_spine.py
@@ -26,6 +26,8 @@ from praxis.core.domain.events import (
     OrderExpired,
     OrderRejected,
     OrderSubmitFailed,
+    OperatorHaltRequested,
+    OperatorResumeRequested,
     OrderSubmitIntent,
     OrderSubmitted,
     RegisterAccount,
@@ -115,6 +117,12 @@ _ALL_EVENTS: list[Event] = [
     FundTransaction(
         account_id=_ACCT, timestamp=_TS,
         fund_transaction_id='fund-1', amount=Decimal('1000'), direction='DEPOSIT',
+    ),
+    OperatorHaltRequested(
+        account_id=_ACCT, timestamp=_TS, reason='manual stop',
+    ),
+    OperatorResumeRequested(
+        account_id=_ACCT, timestamp=_TS, reason='cleared',
     ),
 
 ]
@@ -625,3 +633,13 @@ async def test_fill_atomicity_rollback_failure_does_not_mask_dml_exception(
 
     with pytest.raises(RuntimeError, match='simulated DML failure'):
         await spine.append(_FILL, epoch_id=_EPOCH)
+
+
+def test_operator_halt_requires_a_reason() -> None:
+    with pytest.raises(ValueError, match='reason'):
+        OperatorHaltRequested(account_id=_ACCT, timestamp=_TS, reason='')
+
+
+def test_operator_resume_requires_a_reason() -> None:
+    with pytest.raises(ValueError, match='reason'):
+        OperatorResumeRequested(account_id=_ACCT, timestamp=_TS, reason='')

--- a/tests/test_execution_manager.py
+++ b/tests/test_execution_manager.py
@@ -47,6 +47,8 @@ from praxis.core.generate_client_order_id import generate_client_order_id
 from praxis.infrastructure.event_spine import EventSpine
 from praxis.trading_inbound import TradingInbound
 from praxis.infrastructure.venue_adapter import (
+    OrderBookLevel,
+    OrderBookSnapshot,
     CancelResult,
     ImmediateFill,
     NotFoundError,
@@ -98,6 +100,11 @@ def adapter() -> AsyncMock:
         immediate_fills=(),
     )
     mock.cached_filters.return_value = None
+    mock.query_order_book.return_value = OrderBookSnapshot(
+        bids=(OrderBookLevel(price=Decimal('49990'), qty=Decimal('2')),),
+        asks=(OrderBookLevel(price=Decimal('50010'), qty=Decimal('2')),),
+        last_update_id=1,
+    )
     return mock
 
 

--- a/tests/test_execution_manager_filter_orphan.py
+++ b/tests/test_execution_manager_filter_orphan.py
@@ -47,6 +47,8 @@ from praxis.core.domain.single_shot_params import SingleShotParams
 from praxis.core.execution_manager import ExecutionManager
 from praxis.infrastructure.event_spine import EventSpine
 from praxis.infrastructure.venue_adapter import (
+    OrderBookLevel,
+    OrderBookSnapshot,
     LocalOrderRejectedError,
     SubmitResult,
     VenueAdapter,
@@ -79,6 +81,11 @@ def adapter() -> AsyncMock:
     mock = AsyncMock(spec=VenueAdapter)
     mock.submit_order.return_value = SubmitResult(
         venue_order_id='v-1', status=OrderStatus.OPEN, immediate_fills=(),
+    )
+    mock.query_order_book.return_value = OrderBookSnapshot(
+        bids=(OrderBookLevel(price=Decimal('49990'), qty=Decimal('2')),),
+        asks=(OrderBookLevel(price=Decimal('50010'), qty=Decimal('2')),),
+        last_update_id=1,
     )
     return mock
 

--- a/tests/test_execution_manager_rescue.py
+++ b/tests/test_execution_manager_rescue.py
@@ -32,6 +32,8 @@ from praxis.core.domain.single_shot_params import SingleShotParams
 from praxis.core.execution_manager import ExecutionManager
 from praxis.infrastructure.event_spine import EventSpine
 from praxis.infrastructure.venue_adapter import (
+    OrderBookLevel,
+    OrderBookSnapshot,
     DuplicateClientOrderIdError,
     NotFoundError,
     OrderSubmitTimeoutError,
@@ -82,6 +84,11 @@ def adapter() -> AsyncMock:
     mock = AsyncMock(spec=VenueAdapter)
     mock.submit_order.return_value = SubmitResult(
         venue_order_id='v-1', status=OrderStatus.OPEN, immediate_fills=(),
+    )
+    mock.query_order_book.return_value = OrderBookSnapshot(
+        bids=(OrderBookLevel(price=Decimal('49990'), qty=Decimal('2')),),
+        asks=(OrderBookLevel(price=Decimal('50010'), qty=Decimal('2')),),
+        last_update_id=1,
     )
     return mock
 

--- a/tests/test_execution_manager_slippage.py
+++ b/tests/test_execution_manager_slippage.py
@@ -7,7 +7,7 @@ from datetime import datetime, UTC
 from decimal import Decimal
 from typing import Any
 from typing import cast
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 import pytest_asyncio
@@ -21,6 +21,8 @@ from praxis.core.domain.enums import (
     STPMode,
 )
 from praxis.core.domain.single_shot_params import SingleShotParams
+from praxis.core.domain.trade_command import TradeCommand
+from praxis.core.estimate_slippage import SlippageEstimate
 from praxis.core.execution_manager import ExecutionManager
 from praxis.infrastructure.event_spine import EventSpine
 from praxis.infrastructure.venue_adapter import (
@@ -297,3 +299,50 @@ async def test_logs_execution_slippage_for_sell_side(
     arrival_slippage_bps = _extract_decimal_arg(arrival_records[0], 2)
     assert execution_slippage_bps == Decimal('-4')
     assert arrival_slippage_bps == Decimal('-4')
+
+
+def _guard_manager(max_slippage_bps: Decimal | None) -> ExecutionManager:
+    return ExecutionManager(
+        event_spine=MagicMock(), epoch_id=_EPOCH, venue_adapter=MagicMock(),
+        max_slippage_bps=max_slippage_bps,
+    )
+
+
+def _market_command() -> TradeCommand:
+    return TradeCommand(command_id='c1', **{**_CMD_KWARGS, 'order_type': OrderType.MARKET})
+
+
+def _estimate(slippage_bps: str) -> SlippageEstimate:
+    return SlippageEstimate(
+        mid_price=Decimal('100'), simulated_vwap=Decimal('101'),
+        slippage_estimate_bps=Decimal(slippage_bps),
+    )
+
+
+def test_slippage_guard_rejects_market_over_limit() -> None:
+    reason = _guard_manager(Decimal('20'))._slippage_guard_reason(
+        _market_command(), _estimate('50'),
+    )
+
+    assert reason is not None
+    assert '50' in reason
+
+
+def test_slippage_guard_allows_within_limit() -> None:
+    assert _guard_manager(Decimal('60'))._slippage_guard_reason(
+        _market_command(), _estimate('50'),
+    ) is None
+
+
+def test_slippage_guard_skips_limit_orders() -> None:
+    limit_cmd = TradeCommand(command_id='c1', **_CMD_KWARGS)
+
+    assert _guard_manager(Decimal('20'))._slippage_guard_reason(
+        limit_cmd, _estimate('50'),
+    ) is None
+
+
+def test_slippage_guard_disabled_when_unset() -> None:
+    assert _guard_manager(None)._slippage_guard_reason(
+        _market_command(), _estimate('50'),
+    ) is None

--- a/tests/test_execution_manager_trade_outcome_callback.py
+++ b/tests/test_execution_manager_trade_outcome_callback.py
@@ -24,7 +24,12 @@ from praxis.core.execution_manager import (
     ExecutionManager,
 )
 from praxis.infrastructure.event_spine import EventSpine
-from praxis.infrastructure.venue_adapter import OrderBookLevel, OrderBookSnapshot, SubmitResult, VenueAdapter
+from praxis.infrastructure.venue_adapter import (
+    OrderBookLevel,
+    OrderBookSnapshot,
+    SubmitResult,
+    VenueAdapter,
+)
 
 _TS = datetime(2099, 1, 1, tzinfo=UTC)
 _ACCT = 'acc-1'

--- a/tests/test_execution_manager_trade_outcome_callback.py
+++ b/tests/test_execution_manager_trade_outcome_callback.py
@@ -24,7 +24,7 @@ from praxis.core.execution_manager import (
     ExecutionManager,
 )
 from praxis.infrastructure.event_spine import EventSpine
-from praxis.infrastructure.venue_adapter import SubmitResult, VenueAdapter
+from praxis.infrastructure.venue_adapter import OrderBookLevel, OrderBookSnapshot, SubmitResult, VenueAdapter
 
 _TS = datetime(2099, 1, 1, tzinfo=UTC)
 _ACCT = 'acc-1'
@@ -54,6 +54,11 @@ def adapter() -> AsyncMock:
         venue_order_id='venue-1',
         status=OrderStatus.OPEN,
         immediate_fills=(),
+    )
+    mock.query_order_book.return_value = OrderBookSnapshot(
+        bids=(OrderBookLevel(price=Decimal('49990'), qty=Decimal('2')),),
+        asks=(OrderBookLevel(price=Decimal('50010'), qty=Decimal('2')),),
+        last_update_id=1,
     )
     return mock
 

--- a/tests/test_launcher_health_loop.py
+++ b/tests/test_launcher_health_loop.py
@@ -6,6 +6,7 @@ wired) is already exercised by `test_launcher_outbound_wiring`.
 
 from __future__ import annotations
 
+import threading
 import time
 from decimal import Decimal
 from unittest.mock import MagicMock
@@ -13,6 +14,7 @@ from unittest.mock import MagicMock
 from nexus.core.domain.enums import OperationalMode
 from nexus.core.domain.instance_state import InstanceState
 from nexus.core.health_loop import HealthLoop
+from nexus.core.mode_controller import ModeController
 
 from praxis.core.domain.health_snapshot import HealthSnapshot
 from praxis.launcher import _build_health_loop
@@ -73,6 +75,23 @@ def test_health_loop_transition_updates_instance_state_mode() -> None:
 
     assert state.mode.mode == OperationalMode.HALTED
     assert state.mode.trigger == 'health'
+
+
+def test_build_health_loop_routes_through_mode_controller() -> None:
+    '''A manual hold on the controller survives a healthy tick via the loop.'''
+
+    state = _state()
+    controller = ModeController(state, threading.Lock())
+    controller.set_manual_halt('manual stop')
+    trading = _trading_returning(_healthy_snapshot())
+
+    loop = _build_health_loop(
+        trading, state, account_id='acct-pt54', mode_controller=controller,
+    )
+    loop.tick_once()
+
+    assert state.mode.mode == OperationalMode.HALTED
+    assert state.mode.trigger == 'manual'
     trading.get_health_snapshot_sync.assert_called_once_with('acct-pt54')
 
 

--- a/tests/test_launcher_nexus_instance_config.py
+++ b/tests/test_launcher_nexus_instance_config.py
@@ -6,6 +6,8 @@ from decimal import Decimal
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import pytest
+
 from nexus.core.stp_mode import STPMode
 
 from praxis.launcher import (
@@ -47,6 +49,26 @@ class TestBuildNexusInstanceConfig:
         cfg = _build_nexus_instance_config(_praxis_instance('acct-001'), manifest)
 
         assert cfg.account_id == 'acct-001'
+
+    def test_price_limits_default_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv('PRAXIS_MAX_SPREAD_BPS', raising=False)
+        monkeypatch.delenv('PRAXIS_BOOK_STALENESS_SECONDS', raising=False)
+        manifest = _stub_manifest((_stub_strategy_spec('s', Decimal('100')),))
+
+        cfg = _build_nexus_instance_config(_praxis_instance(), manifest)
+
+        assert cfg.max_spread_bps is None
+        assert cfg.book_staleness_max_seconds is None
+
+    def test_price_limits_read_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv('PRAXIS_MAX_SPREAD_BPS', '25')
+        monkeypatch.setenv('PRAXIS_BOOK_STALENESS_SECONDS', '5')
+        manifest = _stub_manifest((_stub_strategy_spec('s', Decimal('100')),))
+
+        cfg = _build_nexus_instance_config(_praxis_instance(), manifest)
+
+        assert cfg.max_spread_bps == Decimal('25')
+        assert cfg.book_staleness_max_seconds == 5
 
     def test_venue_defaults_to_binance_spot(self) -> None:
         manifest = _stub_manifest((_stub_strategy_spec('s', Decimal('100')),))

--- a/tests/test_launcher_nexus_instance_config.py
+++ b/tests/test_launcher_nexus_instance_config.py
@@ -70,6 +70,25 @@ class TestBuildNexusInstanceConfig:
         assert cfg.max_spread_bps == Decimal('25')
         assert cfg.book_staleness_max_seconds == 5
 
+    def test_book_staleness_at_or_below_poll_interval_rejected(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv('PRAXIS_BOOK_STALENESS_SECONDS', '2')
+        manifest = _stub_manifest((_stub_strategy_spec('s', Decimal('100')),))
+
+        with pytest.raises(ValueError, match='must exceed the book poll interval'):
+            _build_nexus_instance_config(_praxis_instance(), manifest)
+
+    def test_book_staleness_above_poll_interval_accepted(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv('PRAXIS_BOOK_STALENESS_SECONDS', '3')
+        manifest = _stub_manifest((_stub_strategy_spec('s', Decimal('100')),))
+
+        cfg = _build_nexus_instance_config(_praxis_instance(), manifest)
+
+        assert cfg.book_staleness_max_seconds == 3
+
     def test_venue_defaults_to_binance_spot(self) -> None:
         manifest = _stub_manifest((_stub_strategy_spec('s', Decimal('100')),))
 

--- a/tests/test_launcher_ops_endpoint.py
+++ b/tests/test_launcher_ops_endpoint.py
@@ -273,3 +273,18 @@ async def test_close_all_returns_structured_error_on_failure(tmp_path: Path, mon
 
     assert response.status == 500
     assert json.loads(response.body) == {'error': 'close_all_failed'}
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_account_returns_400(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv('PRAXIS_OPS_TOKEN', _TOKEN)
+    launcher = _launcher(await _spine(), tmp_path)
+    _register_runtime(launcher)
+    second = Mock()
+    second.nexus_config.account_id = 'other-acc'
+    launcher._nexus_runtimes['other-acc'] = second
+
+    response = await launcher._ops_status_handler(_request('/ops/status', method='GET'))
+
+    assert response.status == 400
+    assert json.loads(response.body)['error'] == 'account_id_required'

--- a/tests/test_launcher_ops_endpoint.py
+++ b/tests/test_launcher_ops_endpoint.py
@@ -7,7 +7,7 @@ import threading
 from decimal import Decimal
 from pathlib import Path
 from typing import cast
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 import aiosqlite
 import pytest
@@ -18,6 +18,8 @@ from nexus.core.domain.capital_state import CapitalState
 from nexus.core.domain.enums import OperationalMode
 from nexus.core.domain.instance_state import InstanceState
 from nexus.core.mode_controller import ModeController
+from praxis.core.domain.enums import OrderSide, OrderType
+from praxis.core.domain.position import Position
 from praxis.core.domain.events import OperatorHaltRequested, OperatorResumeRequested
 from praxis.infrastructure.event_spine import EventSpine
 from praxis.infrastructure.venue_adapter import VenueAdapter
@@ -177,3 +179,51 @@ async def test_unknown_account_is_not_found(tmp_path: Path, monkeypatch: pytest.
     response = await launcher._ops_status_handler(_request('/ops/status', method='GET'))
 
     assert response.status == 404
+
+
+@pytest.mark.asyncio
+async def test_cancel_all_aborts_working_commands(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv('PRAXIS_OPS_TOKEN', _TOKEN)
+    launcher = _launcher(await _spine(), tmp_path)
+    _register_runtime(launcher)
+    launcher._trading = Mock()
+    launcher._trading.execution_manager.get_open_orders.return_value = {
+        'c1': Mock(command_id='cmd-1'),
+        'c2': Mock(command_id='cmd-1'),
+        'c3': Mock(command_id='cmd-2'),
+    }
+
+    response = await launcher._ops_cancel_all_handler(_request('/ops/cancel-all'))
+    body = json.loads(response.body)
+
+    assert response.status == 200
+    assert body['canceled'] == ['cmd-1', 'cmd-2']
+    assert launcher._trading.submit_abort.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_close_all_submits_market_exits(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv('PRAXIS_OPS_TOKEN', _TOKEN)
+    launcher = _launcher(await _spine(), tmp_path)
+    _register_runtime(launcher)
+    trading = Mock()
+    trading.execution_manager.get_open_orders.return_value = {}
+    trading.pull_positions.return_value = {
+        ('t1', _ACCOUNT): Position(
+            account_id=_ACCOUNT, trade_id='t1', symbol='BTCUSDT',
+            side=OrderSide.BUY, qty=Decimal('2'), avg_entry_price=Decimal('100'),
+        ),
+    }
+    trading.submit_command = AsyncMock(return_value='exit-cmd')
+    launcher._trading = trading
+
+    response = await launcher._ops_close_all_handler(_request('/ops/close-all'))
+    body = json.loads(response.body)
+
+    assert response.status == 200
+    assert body['closed'] == [{'trade_id': 't1', 'command_id': 'exit-cmd', 'qty': '2'}]
+
+    kwargs = trading.submit_command.call_args.kwargs
+    assert kwargs['side'] is OrderSide.SELL
+    assert kwargs['order_type'] is OrderType.MARKET
+    assert kwargs['qty'] == Decimal('2')

--- a/tests/test_launcher_ops_endpoint.py
+++ b/tests/test_launcher_ops_endpoint.py
@@ -1,0 +1,179 @@
+'''Tests for the Launcher `/ops` operator control endpoints.'''
+
+from __future__ import annotations
+
+import json
+import threading
+from decimal import Decimal
+from pathlib import Path
+from typing import cast
+from unittest.mock import Mock
+
+import aiosqlite
+import pytest
+from aiohttp.test_utils import make_mocked_request
+from aiohttp.web import Request
+
+from nexus.core.domain.capital_state import CapitalState
+from nexus.core.domain.enums import OperationalMode
+from nexus.core.domain.instance_state import InstanceState
+from nexus.core.mode_controller import ModeController
+from praxis.core.domain.events import OperatorHaltRequested, OperatorResumeRequested
+from praxis.infrastructure.event_spine import EventSpine
+from praxis.infrastructure.venue_adapter import VenueAdapter
+from praxis.launcher import InstanceConfig, Launcher
+from praxis.trading_config import TradingConfig
+
+from tests.test_launcher import MockVenueAdapter, _make_manifest_yaml
+
+_ACCOUNT = 'test-acc'
+_TOKEN = 'secret-token'  # noqa: S105 - test bearer token, not a real secret
+
+
+async def _spine() -> EventSpine:
+    conn = await aiosqlite.connect(':memory:')
+    spine = EventSpine(conn)
+    await spine.ensure_schema()
+
+    return spine
+
+
+def _request(
+    path: str,
+    method: str = 'POST',
+    remote: str = '127.0.0.1',
+    token: str | None = _TOKEN,
+) -> Request:
+    transport = Mock()
+    transport.get_extra_info = lambda key, default=None: (remote, 0) if key == 'peername' else default
+    headers = {'Authorization': f'Bearer {token}'} if token is not None else {}
+
+    return make_mocked_request(method, path, headers=headers, transport=transport)
+
+
+def _launcher(spine: EventSpine, tmp_path: Path) -> Launcher:
+    exp_dir = tmp_path / 'experiment'
+    exp_dir.mkdir()
+    manifest_path = _make_manifest_yaml(tmp_path, exp_dir)
+    config = TradingConfig(epoch_id=1, account_credentials={_ACCOUNT: ('key', 'secret')})
+    inst = InstanceConfig(
+        account_id=_ACCOUNT, manifest_path=manifest_path,
+        strategies_base_path=tmp_path, state_dir=tmp_path / 'state',
+    )
+
+    return Launcher(
+        trading_config=config, instances=[inst], event_spine=spine,
+        venue_adapter=cast(VenueAdapter, MockVenueAdapter()),
+    )
+
+
+def _register_runtime(launcher: Launcher) -> Mock:
+    state = InstanceState(capital=CapitalState(capital_pool=Decimal('10000')))
+    runtime = Mock()
+    runtime.mode_controller = ModeController(state, threading.Lock())
+    runtime.state = state
+    runtime.state_store = Mock()
+    runtime.nexus_config.account_id = _ACCOUNT
+    launcher._nexus_runtimes[_ACCOUNT] = runtime
+
+    return runtime
+
+
+@pytest.mark.asyncio
+async def test_halt_sets_manual_hold_and_persists(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv('PRAXIS_OPS_TOKEN', _TOKEN)
+    spine = await _spine()
+    launcher = _launcher(spine, tmp_path)
+    runtime = _register_runtime(launcher)
+
+    response = await launcher._ops_halt_handler(_request('/ops/halt'))
+    body = json.loads(response.body)
+
+    assert response.status == 200
+    assert body['mode'] == OperationalMode.HALTED.value
+    assert body['holds']['manual'] is True
+    assert runtime.state.mode.mode is OperationalMode.HALTED
+    runtime.state_store.append_mutation.assert_called_once_with(runtime.state)
+
+    records = await spine.read(1)
+    assert any(isinstance(event, OperatorHaltRequested) for _seq, event in records)
+
+
+@pytest.mark.asyncio
+async def test_resume_clears_manual_hold(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv('PRAXIS_OPS_TOKEN', _TOKEN)
+    spine = await _spine()
+    launcher = _launcher(spine, tmp_path)
+    runtime = _register_runtime(launcher)
+    runtime.mode_controller.set_manual_halt('manual stop')
+
+    response = await launcher._ops_resume_handler(_request('/ops/resume'))
+    body = json.loads(response.body)
+
+    assert response.status == 200
+    assert body['mode'] == OperationalMode.ACTIVE.value
+    assert body['holds']['manual'] is False
+
+    records = await spine.read(1)
+    assert any(isinstance(event, OperatorResumeRequested) for _seq, event in records)
+
+
+@pytest.mark.asyncio
+async def test_status_reports_mode_and_holds(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv('PRAXIS_OPS_TOKEN', _TOKEN)
+    launcher = _launcher(await _spine(), tmp_path)
+    runtime = _register_runtime(launcher)
+    runtime.mode_controller.set_manual_halt('manual stop')
+
+    response = await launcher._ops_status_handler(_request('/ops/status', method='GET'))
+    body = json.loads(response.body)
+
+    assert response.status == 200
+    assert body['account_id'] == _ACCOUNT
+    assert body['mode'] == OperationalMode.HALTED.value
+    assert body['holds']['manual'] is True
+
+
+@pytest.mark.asyncio
+async def test_non_loopback_is_forbidden(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv('PRAXIS_OPS_TOKEN', _TOKEN)
+    launcher = _launcher(await _spine(), tmp_path)
+    _register_runtime(launcher)
+
+    response = await launcher._ops_halt_handler(_request('/ops/halt', remote='10.0.0.5'))
+
+    assert response.status == 403
+
+
+@pytest.mark.asyncio
+async def test_missing_token_config_disables_ops(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv('PRAXIS_OPS_TOKEN', raising=False)
+    launcher = _launcher(await _spine(), tmp_path)
+    _register_runtime(launcher)
+
+    response = await launcher._ops_halt_handler(_request('/ops/halt'))
+
+    assert response.status == 503
+
+
+@pytest.mark.asyncio
+async def test_wrong_token_is_unauthorized(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv('PRAXIS_OPS_TOKEN', _TOKEN)
+    launcher = _launcher(await _spine(), tmp_path)
+    _register_runtime(launcher)
+
+    response = await launcher._ops_halt_handler(
+        _request('/ops/halt', token='wrong'),  # noqa: S106 - test bearer token
+    )
+
+    assert response.status == 401
+
+
+@pytest.mark.asyncio
+async def test_unknown_account_is_not_found(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv('PRAXIS_OPS_TOKEN', _TOKEN)
+    launcher = _launcher(await _spine(), tmp_path)
+
+    response = await launcher._ops_status_handler(_request('/ops/status', method='GET'))
+
+    assert response.status == 404

--- a/tests/test_launcher_ops_endpoint.py
+++ b/tests/test_launcher_ops_endpoint.py
@@ -21,6 +21,7 @@ from nexus.core.mode_controller import ModeController
 from praxis.core.domain.enums import OrderSide, OrderType
 from praxis.core.domain.position import Position
 from praxis.core.domain.events import OperatorHaltRequested, OperatorResumeRequested
+from praxis.infrastructure.alert_sink import AlertSink
 from praxis.infrastructure.event_spine import EventSpine
 from praxis.infrastructure.venue_adapter import VenueAdapter
 from praxis.launcher import InstanceConfig, Launcher
@@ -227,3 +228,20 @@ async def test_close_all_submits_market_exits(tmp_path: Path, monkeypatch: pytes
     assert kwargs['side'] is OrderSide.SELL
     assert kwargs['order_type'] is OrderType.MARKET
     assert kwargs['qty'] == Decimal('2')
+
+
+@pytest.mark.asyncio
+async def test_halt_emits_operator_alert(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv('PRAXIS_OPS_TOKEN', _TOKEN)
+    launcher = _launcher(await _spine(), tmp_path)
+    _register_runtime(launcher)
+    posted: list[dict[str, object]] = []
+
+    async def post(_url: str, payload: dict[str, object]) -> None:
+        posted.append(payload)
+
+    launcher._alert_sink = AlertSink(webhook_url='http://hook', post=post)
+
+    await launcher._ops_halt_handler(_request('/ops/halt'))
+
+    assert any(p['event'] == 'operator_halt' for p in posted)

--- a/tests/test_launcher_ops_endpoint.py
+++ b/tests/test_launcher_ops_endpoint.py
@@ -245,3 +245,31 @@ async def test_halt_emits_operator_alert(tmp_path: Path, monkeypatch: pytest.Mon
     await launcher._ops_halt_handler(_request('/ops/halt'))
 
     assert any(p['event'] == 'operator_halt' for p in posted)
+
+
+@pytest.mark.asyncio
+async def test_cancel_all_returns_structured_error_on_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv('PRAXIS_OPS_TOKEN', _TOKEN)
+    launcher = _launcher(await _spine(), tmp_path)
+    _register_runtime(launcher)
+    launcher._trading = Mock()
+    launcher._trading.execution_manager.get_open_orders.side_effect = RuntimeError('not registered')
+
+    response = await launcher._ops_cancel_all_handler(_request('/ops/cancel-all'))
+
+    assert response.status == 500
+    assert json.loads(response.body) == {'error': 'cancel_all_failed'}
+
+
+@pytest.mark.asyncio
+async def test_close_all_returns_structured_error_on_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv('PRAXIS_OPS_TOKEN', _TOKEN)
+    launcher = _launcher(await _spine(), tmp_path)
+    _register_runtime(launcher)
+    launcher._trading = Mock()
+    launcher._trading.execution_manager.get_open_orders.side_effect = RuntimeError('not registered')
+
+    response = await launcher._ops_close_all_handler(_request('/ops/close-all'))
+
+    assert response.status == 500
+    assert json.loads(response.body) == {'error': 'close_all_failed'}

--- a/tests/test_launcher_ops_endpoint.py
+++ b/tests/test_launcher_ops_endpoint.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import threading
 from decimal import Decimal
@@ -288,3 +289,34 @@ async def test_ambiguous_account_returns_400(tmp_path: Path, monkeypatch: pytest
 
     assert response.status == 400
     assert json.loads(response.body)['error'] == 'account_id_required'
+
+
+@pytest.mark.asyncio
+async def test_mode_halt_alert_delivers_webhook_when_loop_available(tmp_path: Path) -> None:
+    launcher = _launcher(await _spine(), tmp_path)
+    posted: list[dict[str, object]] = []
+
+    async def post(_url: str, payload: dict[str, object]) -> None:
+        posted.append(payload)
+
+    launcher._alert_sink = AlertSink(webhook_url='http://hook', post=post)
+    launcher._loop = asyncio.get_running_loop()
+    on_halt = launcher._build_mode_halt_alert('acc-1')
+
+    on_halt('risk')
+    await asyncio.sleep(0.05)
+
+    assert any(p['event'] == 'mode_halted' and p['source'] == 'risk' for p in posted)
+
+
+@pytest.mark.asyncio
+async def test_mode_halt_alert_logs_only_without_loop(tmp_path: Path) -> None:
+    launcher = _launcher(await _spine(), tmp_path)
+    launcher._alert_sink = Mock()
+    launcher._loop = None
+    on_halt = launcher._build_mode_halt_alert('acc-1')
+
+    on_halt('manual')
+
+    launcher._alert_sink.alert.assert_called_once()
+    launcher._alert_sink.notify.assert_not_called()

--- a/tests/test_launcher_ops_endpoint.py
+++ b/tests/test_launcher_ops_endpoint.py
@@ -320,3 +320,18 @@ async def test_mode_halt_alert_logs_only_without_loop(tmp_path: Path) -> None:
 
     launcher._alert_sink.alert.assert_called_once()
     launcher._alert_sink.notify.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_mode_halt_alert_falls_back_when_loop_closed(tmp_path: Path) -> None:
+    launcher = _launcher(await _spine(), tmp_path)
+    launcher._alert_sink = Mock()
+    loop = asyncio.new_event_loop()
+    loop.close()
+    launcher._loop = loop
+    on_halt = launcher._build_mode_halt_alert('acc-1')
+
+    on_halt('risk')
+
+    launcher._alert_sink.alert.assert_called_once()
+    launcher._alert_sink.notify.assert_not_called()

--- a/tests/test_launcher_shutdown_config_wiring.py
+++ b/tests/test_launcher_shutdown_config_wiring.py
@@ -61,6 +61,7 @@ def _stub_nexus_runtime() -> _NexusRuntime:
         timer_loop=None,
         outcome_loop=MagicMock(),
         health_loop=MagicMock(),
+        mode_controller=MagicMock(),
         snapshot_scheduler=MagicMock(),
         mtm_loop=MagicMock(),
         unknown_submission_monitor=MagicMock(),

--- a/tests/test_launcher_validation_pipeline.py
+++ b/tests/test_launcher_validation_pipeline.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import threading
 from decimal import Decimal
+from types import SimpleNamespace
 
 import pytest
 
@@ -385,7 +387,7 @@ class TestPlatformLimitsMaxPosition:
         state = _instance_state()
         pipeline = _build_validation_pipeline(
             config, _capital_controller(),
-            platform_snapshot_provider=_build_platform_snapshot_provider({'t1': _position('1')}),
+            platform_snapshot_provider=_build_platform_snapshot_provider({'t1': _position('1')}, threading.Lock()),
             platform_limits=PlatformLimitsStageLimits(max_position=Decimal('1')),
         )
 
@@ -399,7 +401,7 @@ class TestPlatformLimitsMaxPosition:
         state = _instance_state()
         pipeline = _build_validation_pipeline(
             config, _capital_controller(),
-            platform_snapshot_provider=_build_platform_snapshot_provider({'t1': _position('0.5')}),
+            platform_snapshot_provider=_build_platform_snapshot_provider({'t1': _position('0.5')}, threading.Lock()),
             platform_limits=PlatformLimitsStageLimits(max_position=Decimal('1')),
         )
 
@@ -412,7 +414,7 @@ class TestPlatformLimitsMaxPosition:
         state = _instance_state()
         pipeline = _build_validation_pipeline(
             config, _capital_controller(),
-            platform_snapshot_provider=_build_platform_snapshot_provider({'t1': _position('1000')}),
+            platform_snapshot_provider=_build_platform_snapshot_provider({'t1': _position('1000')}, threading.Lock()),
         )
 
         decision = pipeline.validate(_enter_context(config=config, state=state))
@@ -443,3 +445,28 @@ class TestEnvPositiveInt:
 
         with pytest.raises(ValueError, match='must be a positive integer'):
             _env_positive_int('PRAXIS_TEST_INT')
+
+
+def test_platform_snapshot_provider_snapshots_under_the_lock() -> None:
+    positions = {'t1': _position('1')}
+    lock = threading.Lock()
+    provider = _build_platform_snapshot_provider(positions, lock)
+    context = SimpleNamespace(
+        symbol='BTCUSDT', order_size=Decimal('0'), order_side=OrderSide.BUY,
+    )
+    done = threading.Event()
+    result: dict[str, object] = {}
+
+    def run() -> None:
+        result['snapshot'] = provider(context)
+        done.set()
+
+    with lock:
+        worker = threading.Thread(target=run, daemon=True)
+        worker.start()
+        blocked = not done.wait(timeout=0.2)
+
+    worker.join(timeout=1.0)
+
+    assert blocked
+    assert result['snapshot'].projected_position == Decimal('1')

--- a/tests/test_launcher_validation_pipeline.py
+++ b/tests/test_launcher_validation_pipeline.py
@@ -29,6 +29,7 @@ from praxis.launcher import (
     _build_platform_snapshot_provider,
     _build_validation_pipeline,
     _env_positive_decimal,
+    _env_positive_int,
     _projected_position,
 )
 
@@ -417,3 +418,28 @@ class TestPlatformLimitsMaxPosition:
         decision = pipeline.validate(_enter_context(config=config, state=state))
 
         assert decision.allowed
+
+
+class TestEnvPositiveInt:
+
+    def test_returns_none_when_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv('PRAXIS_TEST_INT', raising=False)
+
+        assert _env_positive_int('PRAXIS_TEST_INT') is None
+
+    def test_parses_a_positive_int(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv('PRAXIS_TEST_INT', '5')
+
+        assert _env_positive_int('PRAXIS_TEST_INT') == 5
+
+    def test_rejects_a_non_integer(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv('PRAXIS_TEST_INT', 'abc')
+
+        with pytest.raises(ValueError, match='must be an integer'):
+            _env_positive_int('PRAXIS_TEST_INT')
+
+    def test_rejects_a_non_positive_value(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv('PRAXIS_TEST_INT', '0')
+
+        with pytest.raises(ValueError, match='must be a positive integer'):
+            _env_positive_int('PRAXIS_TEST_INT')

--- a/tests/test_launcher_validation_pipeline.py
+++ b/tests/test_launcher_validation_pipeline.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from decimal import Decimal
 
+import pytest
+
 from nexus.core.capital_controller.capital_controller import CapitalController
 from nexus.core.domain.capital_state import CapitalState
 from nexus.core.domain.enums import OrderSide
@@ -11,6 +13,7 @@ from nexus.core.domain.instance_state import InstanceState
 from nexus.core.stp_mode import STPMode
 from nexus.core.validator import (
     HealthStageSnapshot,
+    PlatformLimitsStageLimits,
     PriceCheckSnapshot,
     PriceStageLimits,
     ValidationAction,
@@ -21,7 +24,7 @@ from nexus.core.validator import (
 )
 from nexus.instance_config import InstanceConfig as NexusInstanceConfig
 
-from praxis.launcher import _build_validation_pipeline
+from praxis.launcher import _build_validation_pipeline, _env_positive_decimal
 
 
 def _nexus_config(
@@ -246,3 +249,74 @@ def test_decision_type_returned_is_validation_decision() -> None:
     )
 
     assert isinstance(result, ValidationDecision)
+
+
+class TestPlatformLimitsMaxOrderNotional:
+
+    def test_denies_when_order_notional_exceeds_cap(self) -> None:
+        config = _nexus_config()
+        state = _instance_state()
+        pipeline = _build_validation_pipeline(
+            config, _capital_controller(),
+            platform_limits=PlatformLimitsStageLimits(max_order_notional=Decimal('50')),
+        )
+
+        decision = pipeline.validate(
+            _enter_context(config=config, state=state, order_notional=Decimal('100')),
+        )
+
+        assert not decision.allowed
+        assert decision.failed_stage == ValidationStage.PLATFORM_LIMITS
+
+    def test_allows_when_order_notional_within_cap(self) -> None:
+        config = _nexus_config()
+        state = _instance_state()
+        pipeline = _build_validation_pipeline(
+            config, _capital_controller(),
+            platform_limits=PlatformLimitsStageLimits(max_order_notional=Decimal('50')),
+        )
+
+        decision = pipeline.validate(
+            _enter_context(config=config, state=state, order_notional=Decimal('10')),
+        )
+
+        assert decision.allowed
+
+    def test_unset_cap_allows_any_notional(self) -> None:
+        config = _nexus_config()
+        state = _instance_state()
+        pipeline = _build_validation_pipeline(config, _capital_controller())
+
+        decision = pipeline.validate(
+            _enter_context(
+                config=config, state=state,
+                order_notional=Decimal('1000'), strategy_budget=Decimal('100000'),
+            ),
+        )
+
+        assert decision.allowed
+
+
+class TestEnvPositiveDecimal:
+
+    def test_returns_none_when_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv('PRAXIS_TEST_LIMIT', raising=False)
+
+        assert _env_positive_decimal('PRAXIS_TEST_LIMIT') is None
+
+    def test_parses_a_positive_decimal(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv('PRAXIS_TEST_LIMIT', '2500.50')
+
+        assert _env_positive_decimal('PRAXIS_TEST_LIMIT') == Decimal('2500.50')
+
+    def test_rejects_a_non_decimal(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv('PRAXIS_TEST_LIMIT', 'abc')
+
+        with pytest.raises(ValueError, match='must be a decimal'):
+            _env_positive_decimal('PRAXIS_TEST_LIMIT')
+
+    def test_rejects_a_non_positive_value(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv('PRAXIS_TEST_LIMIT', '0')
+
+        with pytest.raises(ValueError, match='must be a positive finite decimal'):
+            _env_positive_decimal('PRAXIS_TEST_LIMIT')

--- a/tests/test_launcher_validation_pipeline.py
+++ b/tests/test_launcher_validation_pipeline.py
@@ -10,6 +10,7 @@ from nexus.core.capital_controller.capital_controller import CapitalController
 from nexus.core.domain.capital_state import CapitalState
 from nexus.core.domain.enums import OrderSide
 from nexus.core.domain.instance_state import InstanceState
+from nexus.core.domain.position import Position
 from nexus.core.stp_mode import STPMode
 from nexus.core.validator import (
     HealthStageSnapshot,
@@ -24,7 +25,12 @@ from nexus.core.validator import (
 )
 from nexus.instance_config import InstanceConfig as NexusInstanceConfig
 
-from praxis.launcher import _build_validation_pipeline, _env_positive_decimal
+from praxis.launcher import (
+    _build_platform_snapshot_provider,
+    _build_validation_pipeline,
+    _env_positive_decimal,
+    _projected_position,
+)
 
 
 def _nexus_config(
@@ -59,19 +65,30 @@ def _enter_context(
     command_id: str = 'cmd_1',
     order_notional: Decimal = Decimal('100'),
     strategy_budget: Decimal = Decimal('1000'),
+    order_side: OrderSide = OrderSide.BUY,
+    order_size: Decimal = Decimal('0.001'),
 ) -> ValidationRequestContext:
     return ValidationRequestContext(
         strategy_id='strat_a',
         action=ValidationAction.ENTER,
         symbol='BTCUSDT',
-        order_side=OrderSide.BUY,
-        order_size=Decimal('0.001'),
+        order_side=order_side,
+        order_size=order_size,
         command_id=command_id,
         order_notional=order_notional,
         estimated_fees=Decimal('0.1'),
         strategy_budget=strategy_budget,
         state=state,
         config=config,
+    )
+
+
+def _position(
+    size: str, side: OrderSide = OrderSide.BUY, symbol: str = 'BTCUSDT',
+) -> Position:
+    return Position(
+        trade_id=f't-{size}-{symbol}', strategy_id='strat_a', symbol=symbol,
+        side=side, size=Decimal(size), entry_price=Decimal('100'),
     )
 
 
@@ -320,3 +337,83 @@ class TestEnvPositiveDecimal:
 
         with pytest.raises(ValueError, match='must be a positive finite decimal'):
             _env_positive_decimal('PRAXIS_TEST_LIMIT')
+
+
+class TestProjectedPosition:
+
+    def test_adds_buy_order_to_current_position(self) -> None:
+        positions = {'t1': _position('1')}
+        context = _enter_context(
+            config=_nexus_config(), state=_instance_state(),
+            order_side=OrderSide.BUY, order_size=Decimal('0.5'),
+        )
+
+        assert _projected_position(positions, context) == Decimal('1.5')
+
+    def test_projects_from_empty_positions(self) -> None:
+        context = _enter_context(
+            config=_nexus_config(), state=_instance_state(),
+            order_side=OrderSide.BUY, order_size=Decimal('0.5'),
+        )
+
+        assert _projected_position({}, context) == Decimal('0.5')
+
+    def test_sell_reduces_and_floors_at_zero(self) -> None:
+        positions = {'t1': _position('0.3')}
+        context = _enter_context(
+            config=_nexus_config(), state=_instance_state(),
+            order_side=OrderSide.SELL, order_size=Decimal('0.5'),
+        )
+
+        assert _projected_position(positions, context) == Decimal('0')
+
+    def test_ignores_other_symbols(self) -> None:
+        positions = {'t1': _position('1', symbol='ETHUSDT')}
+        context = _enter_context(
+            config=_nexus_config(), state=_instance_state(),
+            order_side=OrderSide.BUY, order_size=Decimal('0.5'),
+        )
+
+        assert _projected_position(positions, context) == Decimal('0.5')
+
+
+class TestPlatformLimitsMaxPosition:
+
+    def test_denies_when_projected_position_exceeds_cap(self) -> None:
+        config = _nexus_config()
+        state = _instance_state()
+        pipeline = _build_validation_pipeline(
+            config, _capital_controller(),
+            platform_snapshot_provider=_build_platform_snapshot_provider({'t1': _position('1')}),
+            platform_limits=PlatformLimitsStageLimits(max_position=Decimal('1')),
+        )
+
+        decision = pipeline.validate(_enter_context(config=config, state=state))
+
+        assert not decision.allowed
+        assert decision.failed_stage == ValidationStage.PLATFORM_LIMITS
+
+    def test_allows_when_projected_position_within_cap(self) -> None:
+        config = _nexus_config()
+        state = _instance_state()
+        pipeline = _build_validation_pipeline(
+            config, _capital_controller(),
+            platform_snapshot_provider=_build_platform_snapshot_provider({'t1': _position('0.5')}),
+            platform_limits=PlatformLimitsStageLimits(max_position=Decimal('1')),
+        )
+
+        decision = pipeline.validate(_enter_context(config=config, state=state))
+
+        assert decision.allowed
+
+    def test_unset_cap_ignores_projected_position(self) -> None:
+        config = _nexus_config()
+        state = _instance_state()
+        pipeline = _build_validation_pipeline(
+            config, _capital_controller(),
+            platform_snapshot_provider=_build_platform_snapshot_provider({'t1': _position('1000')}),
+        )
+
+        decision = pipeline.validate(_enter_context(config=config, state=state))
+
+        assert decision.allowed

--- a/tests/test_launcher_validation_pipeline.py
+++ b/tests/test_launcher_validation_pipeline.py
@@ -464,7 +464,7 @@ def test_platform_snapshot_provider_snapshots_under_the_lock() -> None:
     with lock:
         worker = threading.Thread(target=run, daemon=True)
         worker.start()
-        blocked = not done.wait(timeout=0.2)
+        blocked = not done.wait(timeout=0.5)
 
     worker.join(timeout=1.0)
 

--- a/tests/test_launcher_validation_pipeline.py
+++ b/tests/test_launcher_validation_pipeline.py
@@ -351,7 +351,7 @@ class TestProjectedPosition:
             order_side=OrderSide.BUY, order_size=Decimal('0.5'),
         )
 
-        assert _projected_position(positions, context) == Decimal('1.5')
+        assert _projected_position(positions, context, lambda _s: None) == Decimal('1.5')
 
     def test_projects_from_empty_positions(self) -> None:
         context = _enter_context(
@@ -359,7 +359,7 @@ class TestProjectedPosition:
             order_side=OrderSide.BUY, order_size=Decimal('0.5'),
         )
 
-        assert _projected_position({}, context) == Decimal('0.5')
+        assert _projected_position({}, context, lambda _s: None) == Decimal('0.5')
 
     def test_sell_reduces_and_floors_at_zero(self) -> None:
         positions = {'t1': _position('0.3')}
@@ -368,7 +368,7 @@ class TestProjectedPosition:
             order_side=OrderSide.SELL, order_size=Decimal('0.5'),
         )
 
-        assert _projected_position(positions, context) == Decimal('0')
+        assert _projected_position(positions, context, lambda _s: None) == Decimal('0')
 
     def test_ignores_other_symbols(self) -> None:
         positions = {'t1': _position('1', symbol='ETHUSDT')}
@@ -377,7 +377,7 @@ class TestProjectedPosition:
             order_side=OrderSide.BUY, order_size=Decimal('0.5'),
         )
 
-        assert _projected_position(positions, context) == Decimal('0.5')
+        assert _projected_position(positions, context, lambda _s: None) == Decimal('0.5')
 
 
 class TestPlatformLimitsMaxPosition:
@@ -387,7 +387,7 @@ class TestPlatformLimitsMaxPosition:
         state = _instance_state()
         pipeline = _build_validation_pipeline(
             config, _capital_controller(),
-            platform_snapshot_provider=_build_platform_snapshot_provider({'t1': _position('1')}, threading.Lock()),
+            platform_snapshot_provider=_build_platform_snapshot_provider({'t1': _position('1')}, threading.Lock(), lambda _s: None),
             platform_limits=PlatformLimitsStageLimits(max_position=Decimal('1')),
         )
 
@@ -401,7 +401,7 @@ class TestPlatformLimitsMaxPosition:
         state = _instance_state()
         pipeline = _build_validation_pipeline(
             config, _capital_controller(),
-            platform_snapshot_provider=_build_platform_snapshot_provider({'t1': _position('0.5')}, threading.Lock()),
+            platform_snapshot_provider=_build_platform_snapshot_provider({'t1': _position('0.5')}, threading.Lock(), lambda _s: None),
             platform_limits=PlatformLimitsStageLimits(max_position=Decimal('1')),
         )
 
@@ -414,7 +414,7 @@ class TestPlatformLimitsMaxPosition:
         state = _instance_state()
         pipeline = _build_validation_pipeline(
             config, _capital_controller(),
-            platform_snapshot_provider=_build_platform_snapshot_provider({'t1': _position('1000')}, threading.Lock()),
+            platform_snapshot_provider=_build_platform_snapshot_provider({'t1': _position('1000')}, threading.Lock(), lambda _s: None),
         )
 
         decision = pipeline.validate(_enter_context(config=config, state=state))
@@ -450,7 +450,7 @@ class TestEnvPositiveInt:
 def test_platform_snapshot_provider_snapshots_under_the_lock() -> None:
     positions = {'t1': _position('1')}
     lock = threading.Lock()
-    provider = _build_platform_snapshot_provider(positions, lock)
+    provider = _build_platform_snapshot_provider(positions, lock, lambda _s: None)
     context = SimpleNamespace(
         symbol='BTCUSDT', order_size=Decimal('0'), order_side=OrderSide.BUY,
     )
@@ -470,3 +470,27 @@ def test_platform_snapshot_provider_snapshots_under_the_lock() -> None:
 
     assert blocked
     assert result['snapshot'].projected_position == Decimal('1')
+
+
+def test_projected_position_estimates_quote_native_from_mid() -> None:
+    positions = {'t1': _position('1')}
+    context = SimpleNamespace(
+        symbol='BTCUSDT', order_size=None,
+        order_notional=Decimal('200'), order_side=OrderSide.BUY,
+    )
+
+    result = _projected_position(positions, context, lambda _s: Decimal('100'))
+
+    assert result == Decimal('3')
+
+
+def test_projected_position_quote_native_without_mid_degrades_to_current() -> None:
+    positions = {'t1': _position('1')}
+    context = SimpleNamespace(
+        symbol='BTCUSDT', order_size=None,
+        order_notional=Decimal('200'), order_side=OrderSide.BUY,
+    )
+
+    result = _projected_position(positions, context, lambda _s: None)
+
+    assert result == Decimal('1')

--- a/tests/test_launcher_validation_pipeline.py
+++ b/tests/test_launcher_validation_pipeline.py
@@ -165,7 +165,7 @@ class TestBuildValidationPipeline:
 
         snapshots: list[PriceCheckSnapshot] = []
 
-        def provider() -> PriceCheckSnapshot:
+        def provider(_context: ValidationRequestContext) -> PriceCheckSnapshot:
             snapshot = PriceCheckSnapshot(
                 now_ms=1_700_000_000_000,
                 book_timestamp_ms=1_700_000_000_000,
@@ -189,7 +189,7 @@ class TestBuildValidationPipeline:
         config = _nexus_config(max_spread_bps=Decimal('10'))
         state = _instance_state()
 
-        def provider() -> PriceCheckSnapshot:
+        def provider(_context: ValidationRequestContext) -> PriceCheckSnapshot:
             return PriceCheckSnapshot(spread_bps=Decimal('25'))
 
         pipeline = _build_validation_pipeline(

--- a/tests/test_td014_concurrency.py
+++ b/tests/test_td014_concurrency.py
@@ -30,6 +30,8 @@ from praxis.core.domain.single_shot_params import SingleShotParams
 from praxis.core.execution_manager import ExecutionManager
 from praxis.infrastructure.event_spine import EventSpine
 from praxis.infrastructure.venue_adapter import (
+    OrderBookLevel,
+    OrderBookSnapshot,
     SubmitResult,
     VenueAdapter,
 )
@@ -63,6 +65,11 @@ def adapter() -> AsyncMock:
         venue_order_id='venue-concurrent',
         status=OrderStatus.OPEN,
         immediate_fills=(),
+    )
+    mock.query_order_book.return_value = OrderBookSnapshot(
+        bids=(OrderBookLevel(price=Decimal('49990'), qty=Decimal('2')),),
+        asks=(OrderBookLevel(price=Decimal('50010'), qty=Decimal('2')),),
+        last_update_id=1,
     )
     return mock
 


### PR DESCRIPTION
## What does this PR change?

Closes #8 (WP-Praxis-0008 — Live operability & safety). The live-trading safety controls, pre-trade price/slippage gates, operator control surface, and alerting for the MVP.

### Safety controls
- Pre-trade `PRAXIS_MAX_ORDER_NOTIONAL` (snapshot-free) and context-aware `PRAXIS_MAX_POSITION` caps (projects current position + order delta), rejecting a breaching order before the venue.
- Per-account `ModeController` wired into the health loop; risk breakers configured from the manifest `risk_controls` — a live daily-loss or drawdown breach HALTS the account. `reconcile` re-derives the mode on boot before startup actions drain.

### Operator control
- Loopback + bearer-token (`PRAXIS_OPS_TOKEN`, constant-time compare) `/ops` surface: `halt`, `resume`, `status`, `cancel-all`, `close-all`, with durable holds and `OperatorHaltRequested` / `OperatorResumeRequested` spine audit events.

### Price + slippage gates
- Order-book cache/poller feeding the pre-trade price stage (`build_price_snapshot` → spread + staleness, gated by `PRAXIS_MAX_SPREAD_BPS` / `PRAXIS_BOOK_STALENESS_SECONDS`).
- Reject MARKET orders whose quote-denominated estimated slippage exceeds `PRAXIS_MAX_SLIPPAGE_BPS` (resolves TD-078).

### Alerting + shutdown
- Minimal `AlertSink` (structured log + optional `PRAXIS_ALERT_WEBHOOK_URL`); alerts on any HALT and every operator action.
- Shutdown routes through the Nexus `ModeController` shutdown hold, so an in-flight outcome cannot resume trading mid-shutdown.

Depends on Nexus `0.70.0` (ModeController subsystem, sole `state.mode` writer, shared-lock deadlock fix, `set_shutdown_halt`).

## Tests

Full suite: 1865 passed, 1 skipped. New coverage across the caps, operator endpoints (auth, cancel/close-all), price stage, slippage guard, alert sink, and shutdown-hold routing.

## Checklist

- [x] I have reviewed full diff in “Files changed”
- [x] I left no unnecessary files in the changes
- [x] I ran `python tests/run.py` locally without errors (where applicable)
- [ ] I updated `/docs` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md (unless only docs or other non-code aspect was changed)
- [x] I updated pyproject.toml (unless only docs or other non-code aspect was changed)
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [x] I linked issue to auto-close on merge (e.g., “Fixes #123”) when applicable